### PR TITLE
fix(immich): fresh-start DB cluster, add ScheduledBackup

### DIFF
--- a/.github/workflows/kubeconform.yaml
+++ b/.github/workflows/kubeconform.yaml
@@ -9,6 +9,7 @@ on:
 
 env:
   KUBERNETES_DIR: ./kubernetes
+  HOMEBREW_NO_SANDBOX_LINUX: 1
 
 jobs:
   kubeconform:

--- a/.github/workflows/kubeconform.yaml
+++ b/.github/workflows/kubeconform.yaml
@@ -9,7 +9,6 @@ on:
 
 env:
   KUBERNETES_DIR: ./kubernetes
-  HOMEBREW_NO_SANDBOX_LINUX: 1
 
 jobs:
   kubeconform:
@@ -21,6 +20,9 @@ jobs:
 
       - name: Setup Homebrew
         uses: Homebrew/actions/setup-homebrew@master
+
+      - name: Install bubblewrap
+        run: sudo apt-get install -y bubblewrap
 
       - name: Setup Workflow Tools
         run: brew install fluxcd/tap/flux kubeconform kustomize

--- a/.github/workflows/kubeconform.yaml
+++ b/.github/workflows/kubeconform.yaml
@@ -20,9 +20,8 @@ jobs:
 
       - name: Setup Homebrew
         uses: Homebrew/actions/setup-homebrew@master
-
-      - name: Install bubblewrap
-        run: sudo apt-get install -y bubblewrap
+        with:
+          setup-sandbox: true
 
       - name: Setup Workflow Tools
         run: brew install fluxcd/tap/flux kubeconform kustomize

--- a/.github/workflows/kubeconform.yaml
+++ b/.github/workflows/kubeconform.yaml
@@ -9,6 +9,9 @@ on:
 
 env:
   KUBERNETES_DIR: ./kubernetes
+  KUBECONFORM_VERSION: "0.8.0"
+  KUSTOMIZE_VERSION: "5.8.1"
+  FLUX_VERSION: "2.8.8"
 
 jobs:
   kubeconform:
@@ -18,13 +21,22 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Setup Homebrew
-        uses: Homebrew/actions/setup-homebrew@master
-        with:
-          setup-sandbox: true
-
       - name: Setup Workflow Tools
-        run: brew install fluxcd/tap/flux kubeconform kustomize
+        run: |
+          mkdir -p "${HOME}/.local/bin"
+          echo "${HOME}/.local/bin" >> "${GITHUB_PATH}"
+
+          # kubeconform
+          curl -fsSL "https://github.com/yannh/kubeconform/releases/download/v${KUBECONFORM_VERSION}/kubeconform-linux-amd64.tar.gz" \
+            | tar -xz -C "${HOME}/.local/bin" kubeconform
+
+          # kustomize
+          curl -fsSL "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv${KUSTOMIZE_VERSION}/kustomize_v${KUSTOMIZE_VERSION}_linux_amd64.tar.gz" \
+            | tar -xz -C "${HOME}/.local/bin" kustomize
+
+          # flux (for envsubst)
+          curl -fsSL "https://github.com/fluxcd/flux2/releases/download/v${FLUX_VERSION}/flux_${FLUX_VERSION}_linux_amd64.tar.gz" \
+            | tar -xz -C "${HOME}/.local/bin" flux
 
       - name: Run kubeconform
         shell: bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,10 +60,14 @@ sensitive — same posture as secrets.
   variable (wired through `cluster-secrets`) rather than a literal, and tell the owner which
   variable to populate.
 
-> Note: parts of the existing repo (inherited from the cluster-template and the VPN/downloads
-> stack) still contain literal `192.168.x.x` addresses — some as `${VAR:=default}` fallbacks,
-> some hardcoded (e.g. the `192.168.24.0/24` VPN bridge subnet). New work must not add to this,
-> and scrubbing the existing literals is a tracked cleanup task.
+> **What counts as sensitive here:** the owner's *real* network — LAN/router/NFS/gateway
+> addresses, VLANs — which is already injected via `cluster-secrets` (the `${VAR:=192.168.1.x}`
+> literals scattered through the repo are generic cluster-template fallbacks, not the real
+> values).
+>
+> **Explicitly OK:** the `192.168.24.0/24` VPN subnet and its fixed pod IPs (in
+> `kubernetes/apps/{network,vpn,downloads}` and the VPN plan doc) are an **internal overlay**,
+> not real LAN topology — they may stay hardcoded. Don't waste effort variabilizing them.
 
 ## Execution environment constraints
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,14 +5,30 @@ Guidance for Claude (and other AI agents) working in this repository.
 ## What this repo is
 
 A GitOps home-ops repo (fork of [onedr0p/cluster-template](https://github.com/onedr0p/cluster-template))
-that declaratively manages a single Kubernetes cluster:
+that declaratively manages a single Kubernetes cluster.
+
+**Guiding principle — everything as code.** The whole system is meant to be reproducible from
+this Git repository: no click-ops, no manual `kubectl apply`, no console-configured infra. State
+lives in version control and is reconciled by machines, via two complementary engines:
+
+- **GitOps (Flux)** for everything *inside* the cluster — a push to the tracked branch is the only
+  thing that changes cluster state.
+- **OpenTofu** (the `tofu` CLI, the open-source Terraform fork) for everything *outside* the
+  cluster — Authentik objects, Bitwarden items, MinIO buckets. The `terraform/` directory holds
+  this IaC; `.tf`/`.hcl` is OpenTofu code regardless of the directory name. Prefer `tofu` over
+  `terraform` in new tooling/docs.
+
+When something can't yet be expressed as code, treat that as a gap to close, and call it out
+rather than papering over it with a manual step.
+
+The pieces:
 
 - **OS / cluster**: Talos Linux, bootstrapped via the `talos` taskfiles.
 - **GitOps engine**: Flux — everything under `kubernetes/` is reconciled from Git. A push to
   the tracked branch is what changes the cluster; `kubectl apply` is not part of the workflow.
 - **App pattern**: most apps use the bjw-s `app-template` Helm chart, laid out as
   `kubernetes/apps/<namespace>/<app>/{ks.yaml, app/{helmrelease.yaml, kustomization.yaml, ...}}`.
-- **Out-of-cluster config**: `terraform/` manages things that live outside Kubernetes
+- **Out-of-cluster config**: OpenTofu code in `terraform/` manages things that live outside Kubernetes
   (Authentik objects, Bitwarden items, MinIO buckets) with SOPS-encrypted state inputs.
 - **Storage**: a Synology NAS (RAID 1) is the durable data tier, exposed to the cluster over
   NFS (e.g. Immich data lives on `nfs://<nas>/volume1/immich`). openebs-hostpath is used for
@@ -36,7 +52,7 @@ Concretely:
   `key: "immich credentials"`, `property: pg_password`) — the values themselves live in
   Bitwarden, which I have no access to.
 - **What this means for my work**: I edit the *declarations* — HelmReleases, Kustomizations,
-  ExternalSecret/SOPS *references*, Terraform resources. When a new secret is needed I add the
+  ExternalSecret/SOPS *references*, OpenTofu resources. When a new secret is needed I add the
   `ExternalSecret`/SOPS reference and tell the owner exactly which **Bitwarden item + property**
   (or which SOPS key) they must create and populate. I do **not** invent, guess, paste, or
   commit real secret values, and I assume any value I can't see is being supplied by the owner.
@@ -81,6 +97,27 @@ sensitive — same posture as secrets.
   over claiming runtime verification.
 - Outbound network access depends on the environment's network policy; don't assume arbitrary
   egress.
+
+## Commands
+
+Tasks are driven by [go-task](https://taskfile.dev); run `task -l` to list everything. The
+includes are namespaced (`task k8s:…`, `task flux:…`, `task talos:…`, `task sops:…`). The
+cluster-touching tasks (`flux:*`, `talos:*`, anything needing `KUBECONFIG`) **won't work in this
+container** — no kubeconfig, no cluster. The ones below are the locally useful, read-only/validation
+ones that mirror CI.
+
+- **Validate manifests (kubeconform)** — `task k8s:kubeconform` (wraps `scripts/kubeconform.sh`,
+  same as `.github/workflows/kubeconform.yaml`). Run this after editing any HelmRelease/Kustomization.
+- **Flux diff (what would change on the cluster)** — CI uses the `ghcr.io/allenporter/flux-local`
+  image to `diff helmrelease` and `diff kustomization` (see `.github/workflows/flux-diff.yaml`); run
+  `flux-local` locally the same way to preview a change before pushing.
+- **Lint** — `yamllint .` (config in `.yamllint.yaml`) and `pre-commit run --all-files`
+  (`.pre-commit-config.yaml`: trailing whitespace, EOF, merge-conflict, JSON checks).
+- **Encrypt a SOPS file** — `task sops:encrypt file=<path>` (in-place). Decryption requires the age
+  key, which is not present here — see the secrets section.
+- **Render the cluster-template** — `task configure` regenerates `kubernetes/` and `ansible/` from
+  `config.yaml` via makejinja; only relevant when changing template inputs, and it **overwrites**
+  generated files.
 
 ## Conventions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,72 @@
+# CLAUDE.md
+
+Guidance for Claude (and other AI agents) working in this repository.
+
+## What this repo is
+
+A GitOps home-ops repo (fork of [onedr0p/cluster-template](https://github.com/onedr0p/cluster-template))
+that declaratively manages a single Kubernetes cluster:
+
+- **OS / cluster**: Talos Linux, bootstrapped via the `talos` taskfiles.
+- **GitOps engine**: Flux — everything under `kubernetes/` is reconciled from Git. A push to
+  the tracked branch is what changes the cluster; `kubectl apply` is not part of the workflow.
+- **App pattern**: most apps use the bjw-s `app-template` Helm chart, laid out as
+  `kubernetes/apps/<namespace>/<app>/{ks.yaml, app/{helmrelease.yaml, kustomization.yaml, ...}}`.
+- **Out-of-cluster config**: `terraform/` manages things that live outside Kubernetes
+  (Authentik objects, Bitwarden items, MinIO buckets) with SOPS-encrypted state inputs.
+- **Storage**: a Synology NAS (RAID 1) is the durable data tier, exposed to the cluster over
+  NFS (e.g. Immich data lives on `nfs://<nas>/volume1/immich`). openebs-hostpath is used for
+  ephemeral/local PVCs; CNPG Postgres backups go to MinIO (S3).
+
+## ⚠️ Secrets: I do not have them, and that is by design
+
+**I (Claude) cannot read or decrypt the real secret values in this repo, and I should never
+try to.** The owner injects all sensitive material securely, outside of anything I can see.
+Concretely:
+
+- **SOPS / age**: files matching `*.sops.yaml` (and the patterns in `.sops.yaml`) are
+  encrypted with an **age key that is not present in this environment**. I cannot decrypt them,
+  and I should not attempt to (`sops -d`, `task sops:*`, importing keys, etc. will fail and are
+  not expected to succeed). The age **public** key in `.sops.yaml` is fine to see; the private
+  key is held only by the owner / the cluster.
+- **External Secrets + Bitwarden**: live secrets are pulled at runtime by
+  [external-secrets](https://external-secrets.io) from Bitwarden via the
+  `bitwarden-login` and `bitwarden-fields` `ClusterSecretStore`s. The `ExternalSecret`
+  manifests in this repo only reference Bitwarden item **names and property keys** (e.g.
+  `key: "immich credentials"`, `property: pg_password`) — the values themselves live in
+  Bitwarden, which I have no access to.
+- **What this means for my work**: I edit the *declarations* — HelmReleases, Kustomizations,
+  ExternalSecret/SOPS *references*, Terraform resources. When a new secret is needed I add the
+  `ExternalSecret`/SOPS reference and tell the owner exactly which **Bitwarden item + property**
+  (or which SOPS key) they must create and populate. I do **not** invent, guess, paste, or
+  commit real secret values, and I assume any value I can't see is being supplied by the owner.
+
+If a task seems to require a secret value I can't see, that's expected — surface what's needed
+and hand that step back to the owner rather than trying to work around the encryption.
+
+## Execution environment constraints
+
+- This runs in an **ephemeral remote container with a fresh clone** — there is **no kubeconfig
+  and no cluster access**. I cannot run `kubectl`, `flux`, or `talosctl` against the live
+  cluster, and I should not assume I can observe runtime state. Changes take effect only after
+  the owner reconciles Flux from the pushed branch.
+- Validation I *can* do locally: schema/lint checks the way CI does them — `kubeconform`
+  (see `.github/workflows/kubeconform.yaml`), `flux-local` diffs
+  (`.github/workflows/flux-diff.yaml`), `yamllint`, and the `pre-commit` hooks. Prefer these
+  over claiming runtime verification.
+- Outbound network access depends on the environment's network policy; don't assume arbitrary
+  egress.
+
+## Conventions
+
+- Keep the existing layout: per-app `ks.yaml` Flux Kustomization + an `app/` dir with the
+  HelmRelease and a `kustomization.yaml`. Wire new apps into the parent namespace
+  `kustomization.yaml`.
+- Cross-cutting variables come from Flux substitution: `${SECRET_DOMAIN}`, `${SECRET_NFS_SERVER}`,
+  `${LB_CIDR_V4}`, etc. Reference those rather than hardcoding domains/IPs.
+- Secret plumbing is **always** via `ExternalSecret` (Bitwarden) or `*.sops.yaml`, never plaintext
+  in a manifest. Match the style of the nearest existing `externalsecret.yaml`.
+- Larger multi-step efforts are written up first as dated design docs in `docs/plans/`
+  (see the VPN-gateway and Cilium Gateway API plans for the expected format). Follow that
+  convention for non-trivial changes.
+- Don't commit or push unless asked; when asked, develop on the designated feature branch.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,27 @@ Concretely:
 If a task seems to require a secret value I can't see, that's expected — surface what's needed
 and hand that step back to the owner rather than trying to work around the encryption.
 
+## ⚠️ Network details stay out of the repo
+
+The owner does **not** want real network topology committed to this repo. Treat IPs, CIDRs,
+subnets, gateway/router addresses, NFS server addresses, MAC addresses, VLAN IDs, and similar as
+sensitive — same posture as secrets.
+
+- **Never hardcode** a real address in a manifest, doc, or commit. Reference a Flux substitution
+  variable instead — `${SECRET_NFS_SERVER}`, `${LB_CIDR_V4}`, `${ROUTER_CIDR_V4}`,
+  `${IOT_CIDR}`, etc. The real values live in `cluster-secrets` (SOPS), which the owner injects.
+- In `docs/` and plan files, refer to hosts by name (`auth.${SECRET_DOMAIN}`) or by role
+  ("the VPN gateway pod"), not by address. Use placeholders (`A.B.C.D`, `<nas-ip>`) if an example
+  is unavoidable.
+- When adding config that needs an address, add a new `${SECRET_*}`/`${*_CIDR_*}` substitution
+  variable (wired through `cluster-secrets`) rather than a literal, and tell the owner which
+  variable to populate.
+
+> Note: parts of the existing repo (inherited from the cluster-template and the VPN/downloads
+> stack) still contain literal `192.168.x.x` addresses — some as `${VAR:=default}` fallbacks,
+> some hardcoded (e.g. the `192.168.24.0/24` VPN bridge subnet). New work must not add to this,
+> and scrubbing the existing literals is a tracked cleanup task.
+
 ## Execution environment constraints
 
 - This runs in an **ephemeral remote container with a fresh clone** — there is **no kubeconfig

--- a/docs/plans/2026-06-13-home-identity-and-photo-lifecycle.md
+++ b/docs/plans/2026-06-13-home-identity-and-photo-lifecycle.md
@@ -1,0 +1,228 @@
+# Home Identity (SSO) + Photo Lifecycle Plan
+
+**Date:** 2026-06-13
+**Status:** Draft / not yet started
+
+---
+
+## Goal
+
+Build a home services stack that a non-operator (my wife) could take over and keep running,
+with two near-term pillars:
+
+1. **Self-hosted photos & videos** via Immich, with data on the Synology NAS (RAID 1, NFS).
+2. **No local accounts** — sign in with a Google account. Authentik is the identity broker:
+   Google federates *into* Authentik, and apps (starting with Immich) trust Authentik via OIDC.
+
+> **Why broker through Authentik instead of pointing Immich straight at Google?**
+> A single broker means one place to manage users, groups, and which apps a person can reach.
+> It keeps app config uniform (every app speaks OIDC to Authentik), lets us add non-Google
+> login methods later without touching each app, and gives a clean "who can log in" story for
+> someone inheriting the system. It also lets us invite family members who don't have Google
+> accounts later if needed.
+
+### Success criteria
+
+- Authentik is healthy, backed up, and reachable at `auth.${SECRET_DOMAIN}`.
+- A Google account can log into Authentik and, through it, into Immich — no local Immich account.
+- Immich photos/videos are stored on the NAS and survive a cluster rebuild.
+- The photo lifecycle (wife's phone → shared storage → Immich) is documented and at least
+  partially automated.
+
+---
+
+## Identity architecture (target)
+
+```
+Google account
+   │  (OAuth — Google is a federated "Source" in Authentik)
+   ▼
+Authentik  (auth.${SECRET_DOMAIN})  ── identity broker / user + group store
+   │  (OIDC — Authentik is the "Provider", one per app)
+   ▼
+Immich (photos.${SECRET_DOMAIN})   [and later: Grafana, etc.]
+```
+
+- **Authentik Sources** = inbound identity (Google, GitHub).
+- **Authentik Providers + Applications** = outbound trust to each app (Immich today).
+- **Authentik Groups** = authorization (who may reach which app).
+- Terraform (`terraform/authentik/`) manages all of the above declaratively and stores the
+  generated per-app OIDC client id/secret in Bitwarden via the `oidc_creds` module.
+
+---
+
+## Current state assessment (from the manifests)
+
+What already exists in the repo:
+
+| Area | State |
+|------|-------|
+| Authentik deploy | `kubernetes/apps/security/authentik` — Helm chart `2024.12.0`, external Postgres (CNPG `postgres-rw`) + dragonfly redis, secret via ExternalSecret → Bitwarden. Ingress `auth.${SECRET_DOMAIN}` (class `external`). |
+| Authentik config (TF) | Flows, stages, prompts, brand, groups (`users`, `Home`, `Infrastructure`, `media`), a **GitHub** OAuth source, and an Immich OAuth2 provider/application. |
+| Immich deploy | `kubernetes/apps/default/immich` — server (`api` worker) + microservices (non-`api` workers), v2.5.5, CNPG pgvecto.rs DB with MinIO backups, ML, NFS data PVC (`/volume1/immich`, 2 TB PV). Ingress `photos.${SECRET_DOMAIN}` (class `internal`). |
+| Secrets | External Secrets via Bitwarden (`bitwarden-login`, `bitwarden-fields` ClusterSecretStores) + SOPS/age for Talos/TF state. **Owner-injected — not visible to AI agents.** |
+
+### Findings / bugs to fix (discovered while reviewing)
+
+1. **No Google source exists yet.** `terraform/authentik/main.tf` defines a GitHub
+   `authentik_source_oauth` and a half-written `authentik_policy_expression.google_username`
+   (its body is commented out and it `return False`s), but there is **no
+   `authentik_source_oauth` of `provider_type = "google"`**. This is the core missing piece for
+   the stated goal.
+
+2. **`application_immich.tf` is copy-pasted from Grafana.** Several fields still point at
+   Grafana and must be corrected:
+   - `meta_icon` → a Grafana PNG (should be an Immich icon).
+   - `meta_launch_url` → `https://grafana.${var.domain}/login/generic_oauth` (should be the
+     Immich URL).
+   - `slug` is set to the provider *name* (`immich-provider`) rather than a clean app slug.
+   - `group = authentik_group.monitoring.name` — verify a `monitoring` group is actually
+     defined (it is **not** in `directory.tf`; likely declared in `application_grafana.tf`).
+     Immich should bind the `users`/`media` group, not `monitoring`.
+
+3. **Hostname mismatch between Immich and its OAuth redirect URIs.** The Immich ingress serves
+   `photos.${SECRET_DOMAIN}` (`immich/app/server/helmrelease.yaml`), but
+   `application_immich.tf` registers redirect URIs against `https://immich.${var.domain}/...`.
+   These must agree or OAuth login will fail. **Decision needed:** standardize on `photos.` or
+   `immich.` (see Open Questions). The mobile-app redirect `app.immich://oauth-callback` is
+   correct regardless.
+
+4. **Stale Immich configmap.** `immich/app/configmap.yaml` still carries legacy keys that
+   modern Immich (v2.x) ignores: `TYPESENSE_*`, `IMMICH_WEB_URL`, `IMMICH_SERVER_URL`,
+   `IMMICH_MACHINE_LEARNING_URL`. Harmless but misleading; clean them up.
+
+5. **Immich OAuth is configured in-app, not by env/configmap.** Immich reads its OAuth settings
+   from the database (admin UI / system config), so after the Authentik provider exists, the
+   OAuth issuer URL, client id, and client secret must be entered in Immich's admin settings
+   (or pushed via Immich's config). Plan for a manual admin step here.
+
+> **I cannot verify live state from this environment** (ephemeral container, no kubeconfig).
+> Phase 0 below lists the checks for the owner to run; everything above is from static review.
+
+---
+
+## Phase 0 — Verify what's actually running (owner runs these)
+
+Before changing anything, confirm the foundation. Run on a workstation with cluster access:
+
+```bash
+# Authentik up and reachable?
+flux -n security get hr authentik
+kubectl -n security get pods -l app.kubernetes.io/instance=authentik
+kubectl -n security get ingress           # expect auth.<domain>
+# DB + redis dependencies
+kubectl -n database get cluster            # CNPG postgres healthy?
+kubectl -n database get pods -l app=dragonfly
+
+# Immich up?
+flux -n default get hr immich-server immich-microservices immich-machine-learning
+kubectl -n default get pods -l app.kubernetes.io/name=immich
+kubectl -n default get pvc immich-data     # NFS bound?
+
+# External Secrets resolving from Bitwarden?
+kubectl -n security get externalsecret authentik
+kubectl -n default get externalsecret
+```
+
+**Outcome decides the path:** if Authentik can't log in or its ExternalSecret/DB is unhealthy,
+Phase 1 starts with debugging that; otherwise Phase 1 is purely additive (Google source).
+
+---
+
+## Phase 1 — Authentik: solid base + Google login
+
+1. **Stabilize** (only if Phase 0 shows problems): resolve ExternalSecret/DB/redis issues so the
+   admin UI logs in and `terraform plan` against Authentik works.
+2. **Create the Google OAuth client** in Google Cloud Console (OAuth consent screen + Web
+   client). Authorized redirect URI:
+   `https://auth.${SECRET_DOMAIN}/source/oauth/callback/google/`.
+   - **Secret handling:** store the client id + secret as a Bitwarden item (e.g.
+     `google-oauth credentials`). I will only reference it by item/property in Terraform —
+     **the owner creates and fills the Bitwarden item.**
+3. **Add a Google source in Terraform** (`terraform/authentik/sources.tf`, new file or extend
+   `main.tf`): an `authentik_source_oauth` with `provider_type = "google"`, wired to the
+   enrollment/authentication flows, pulling `consumer_key`/`consumer_secret` from the Bitwarden
+   item. Finish the `google_username` mapping (set username from the email local-part) instead
+   of the current `return False` stub.
+4. **Decide enrollment policy:** restrict sign-up to specific Google emails (you + wife) vs.
+   open enrollment. Likely an allow-list policy bound to the enrollment flow.
+5. `terraform apply`, then verify the Google button appears on `auth.${SECRET_DOMAIN}` and a
+   Google login creates/links an Authentik user.
+
+---
+
+## Phase 2 — Immich SSO via Authentik
+
+1. **Fix `application_immich.tf`** (finding #2): correct `meta_icon`, `meta_launch_url`, `slug`,
+   and bind the right group (`users`/`media`, not `monitoring`).
+2. **Reconcile the hostname** (finding #3): pick `photos.` or `immich.` and make the ingress
+   host and the Authentik `allowed_redirect_uris` match. Keep `app.immich://oauth-callback`.
+3. `terraform apply` to (re)create the Immich OAuth2 provider; the client id/secret land in
+   Bitwarden via the `oidc_creds` module.
+4. **Enable OAuth inside Immich** (finding #5): in Immich admin → Settings → OAuth, set issuer
+   `https://auth.${SECRET_DOMAIN}/application/o/<immich-slug>/`, client id, client secret,
+   button text, and enable auto-register. (Manual admin step — values come from the Bitwarden
+   item created in step 3.)
+5. **Test the full chain:** Google → Authentik → Immich web login, and the mobile app's
+   "Login with OAuth" using `app.immich://oauth-callback`.
+
+---
+
+## Phase 3 — Immich manifest cleanup (low risk)
+
+- Remove stale keys from `immich/app/configmap.yaml` (finding #4): `TYPESENSE_*`,
+  `IMMICH_WEB_URL`, `IMMICH_SERVER_URL`, `IMMICH_MACHINE_LEARNING_URL`.
+- Confirm the server/microservices `IMMICH_WORKERS_INCLUDE/EXCLUDE` split is still the intended
+  topology for v2.x (it is valid; just confirm it's deliberate).
+- Validate with `kubeconform` + `flux-local` the same way CI does before pushing.
+
+---
+
+## Phase 4 — Photo lifecycle (after identity is solid)
+
+Target the wife's existing habit rather than replacing it. Today: phone → OneDrive → desktop →
+manual organization. Previously Syncthing on her PC synced into a shared drive (not yet restored
+on the NAS).
+
+Proposed approach (to be detailed in its own plan doc when we get here):
+
+1. **Restore Syncthing as the bridge to the NAS.** Run Syncthing (likely on the Synology, or as
+   a cluster app writing to the NFS share) so her organized desktop folder syncs to a NAS
+   directory — re-establishing the workflow she already knows.
+2. **Expose that NAS directory to Immich as an External Library** (read-only import) so Immich
+   indexes the curated photos without taking ownership of the files. This keeps her
+   folder-based organization as the source of truth and Immich as the viewer/dedup/ML layer.
+3. **Decide upload ownership:** her curated library via External Library vs. direct
+   phone-upload into Immich. Likely: keep OneDrive→desktop→Syncthing→NAS for her, and use
+   Immich mobile auto-backup only for accounts that want it.
+4. Document the whole flow in `docs/` so it can be operated without me.
+
+> Deferred deliberately — per the request, fix the Kubernetes services (Immich + Authentik)
+> first, then build the lifecycle on the now-stable base.
+
+---
+
+## Secrets the owner must provision (I only reference them)
+
+| Bitwarden item (suggested) | Used by | Notes |
+|----------------------------|---------|-------|
+| `google-oauth credentials` | Authentik Google source (Phase 1) | Google Cloud OAuth web-client id/secret. |
+| `authentik-client-immich` | Immich OAuth2 (Phase 2) | **Auto-created** by the `oidc_creds` TF module; just used by Immich admin config. |
+
+All other secrets (Authentik secret key, Postgres creds, MinIO) already exist as
+ExternalSecret references and are owner-managed.
+
+---
+
+## Open questions for the owner
+
+1. **Immich hostname:** standardize on `photos.${SECRET_DOMAIN}` (current ingress) or
+   `immich.${SECRET_DOMAIN}` (current TF redirect URIs)?
+2. **Who may enroll via Google** — allow-list specific emails, or open self-registration?
+3. **GitHub source:** keep the existing GitHub login source, or remove it in favor of Google-only?
+4. **Immich access exposure:** Immich ingress is class `internal` while Authentik is `external`.
+   Should Immich stay LAN/VPN-only, or be reachable externally (changes the OAuth redirect and
+   security posture)?
+5. **Phase 4 Syncthing placement:** run on the Synology directly, or as a cluster app mounting
+   the NFS share?
+```

--- a/kubernetes/apps/default/immich/app/database/cluster.yaml
+++ b/kubernetes/apps/default/immich/app/database/cluster.yaml
@@ -51,7 +51,7 @@ spec:
         maxParallel: 2
       destinationPath: s3://databases/
       endpointURL: https://s3.${SECRET_DOMAIN:=internal}
-      serverName: immich-v2
+      serverName: immich-v3
       s3Credentials:
         accessKeyId:
           name: minio-immich-pgsql
@@ -59,14 +59,7 @@ spec:
         secretAccessKey:
           name: minio-immich-pgsql
           key: minio_s3_secret_access_key
-  # Note: previousCluster needs to be set to the name of the previous
-  # cluster when recovering from an existing cnpg cluster
   bootstrap:
-    recovery:
-      source: &previousCluster immich-v1
-  # Note: externalClusters is needed when recovering from an existing cnpg cluster
-  externalClusters:
-    - name: *previousCluster
-      barmanObjectStore:
-        <<: *barmanObjectStore
-        serverName: *previousCluster
+    initdb:
+      database: app
+      owner: app

--- a/kubernetes/apps/default/immich/app/database/kustomization.yaml
+++ b/kubernetes/apps/default/immich/app/database/kustomization.yaml
@@ -4,3 +4,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./cluster.yaml
+  - ./scheduledbackup.yaml

--- a/kubernetes/apps/default/immich/app/database/scheduledbackup.yaml
+++ b/kubernetes/apps/default/immich/app/database/scheduledbackup.yaml
@@ -1,0 +1,13 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/postgresql.cnpg.io/scheduledbackup_v1.json
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: immich-database
+  namespace: default
+spec:
+  schedule: "@daily"
+  immediate: true
+  backupOwnerReference: self
+  cluster:
+    name: immich-database


### PR DESCRIPTION
## Summary

- Switches `immich-database` CNPG cluster bootstrap from `recovery` (broken) to `initdb` (fresh start)
- Renames barman `serverName` from `immich-v2` to `immich-v3` so the new cluster writes to a clean S3 prefix
- Removes the now-unused `externalClusters` block
- Adds a `ScheduledBackup` running `@daily` so base backups are taken going forward

## Why

The cluster has been stuck since 2026-02-08 (125 days). Every startup attempt fails with:

> `WAL archive check failed for server immich-v2: Expected empty archive`

CNPG's pre-flight safety check blocks recovery because `s3://databases/immich-v2/` already contains data from a prior cluster run. A backup-based recovery is also not possible — no base backups exist in MinIO (oldest data is WAL-only from 2024-05-19, long since pruned by the 30-day retention). The cluster never had a `ScheduledBackup`, which is why no base backup was ever written.

Photo/video files are safe on NFS (`/volume1/immich`). The Postgres DB (users, albums, metadata) was never successfully bootstrapped, so there is nothing to lose.

## Apply procedure

Before Flux can reconcile, delete the stuck cluster and its (already-absent) PVC:

```bash
flux suspend ks cluster-apps-immich
kubectl delete cluster immich-database -n default
# PVC immich-database-1 was never created — skip
flux reconcile source git home-kubernetes
flux resume ks cluster-apps-immich
kubectl get cluster immich-database -n default -w
```

After the cluster reaches `Cluster in healthy state`, the Immich HelmReleases will auto-heal. First login creates a fresh admin account; photos on NFS need to be re-scanned via an Immich library scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)