### PR TITLE
fix(postgres): fresh-start shared cluster with initdb

### DIFF
--- a/kubernetes/apps/database/cloudnative-pg/cluster/cluster.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/cluster.yaml
@@ -47,7 +47,7 @@ spec:
         maxParallel: 2
       destinationPath: s3://databases/
       endpointURL: https://s3.${SECRET_DOMAIN:=internal}
-      serverName: postgres16-v2
+      serverName: postgres16-v3
       s3Credentials:
         accessKeyId:
           name: minio-pgsql
@@ -55,14 +55,7 @@ spec:
         secretAccessKey:
           name: minio-pgsql
           key: minio_s3_secret_access_key
-  # Note: previousCluster needs to be set to the name of the previous
-  # cluster when recovering from an existing cnpg cluster
   bootstrap:
-    recovery:
-      source: &previousCluster postgres16-v1
-  # Note: externalClusters is needed when recovering from an existing cnpg cluster
-  externalClusters:
-    - name: *previousCluster
-      barmanObjectStore:
-        <<: *barmanObjectStore
-        serverName: *previousCluster
+    initdb:
+      database: app
+      owner: app


### PR DESCRIPTION
## Summary
- Switches `bootstrap` from `recovery` (postgres16-v1) to `initdb` — same fix applied to `immich-database` in #1075
- Bumps `serverName` from `postgres16-v2` to `postgres16-v3` to clear the CNPG WAL archive safety check
- Removes `externalClusters` block (no longer needed)

## Root cause
Cluster has been stuck since 2026-02-08: `bootstrap.recovery` was pointing at `postgres16-v1` but `postgres16-v2` was already non-empty in MinIO, triggering CNPG's WAL archive check which blocks bootstrap.

## After merging
Before Flux reconciles, run:
```bash
# Delete the stuck PVC (annotated 'initializing' — no real data written)
kubectl delete pvc postgres-1 -n database

# Clean up stuck Backup objects so CNPG reconciliation isn't starved
kubectl delete backup -n database --field-selector=status.phase=pending
kubectl delete backup -n database --field-selector=status.phase=failed
```

Then watch the cluster come up:
```bash
kubectl get cluster postgres -n database -w
```

## Test plan
- [ ] Merge and run the imperative cleanup steps above
- [ ] `postgres` cluster reaches `Cluster in healthy state`
- [ ] `postgres-1`, `postgres-2`, `postgres-3` pods all Running
- [ ] Authentik pods start connecting

🤖 Generated with [Claude Code](https://claude.com/claude-code)