### PR TITLE
chore: remove Cloudflare integration

### DIFF
--- a/.devcontainer/ci/features/install.sh
+++ b/.devcontainer/ci/features/install.sh
@@ -19,8 +19,7 @@ for app in \
     "budimanjojo/talhelper!" \
     "cilium/cilium-cli!!?as=cilium&type=script" \
     "cli/cli!!?as=gh&type=script" \
-    "cloudflare/cloudflared!!?as=cloudflared&type=script" \
-    "derailed/k9s!!?as=k9s&type=script" \
+"derailed/k9s!!?as=k9s&type=script" \
     "direnv/direnv!!?as=direnv&type=script" \
     "fluxcd/flux2!!?as=flux&type=script" \
     "go-task/task!!?as=task&type=script" \

--- a/.github/tests/config-k3s-ipv4.yaml
+++ b/.github/tests/config-k3s-ipv4.yaml
@@ -40,17 +40,3 @@ flux:
       enabled: false
   sops_age_public_key: $BOOTSTRAP_AGE_PUBLIC_KEY
 
-cloudflare:
-  enabled: true
-  domain: fake
-  token: take
-  acme:
-    email: fake@example.com
-    production: false
-  tunnel:
-    account_id: fake
-    id: fake
-    secret: fake
-    ingress_vip: 10.10.10.252
-  ingress_vip: 10.10.10.251
-  gateway_vip: 10.10.10.253

--- a/.github/tests/config-k3s-ipv6.yaml
+++ b/.github/tests/config-k3s-ipv6.yaml
@@ -39,20 +39,6 @@ flux:
       enabled: false
   sops_age_public_key: $BOOTSTRAP_AGE_PUBLIC_KEY
 
-cloudflare:
-  enabled: true
-  domain: fake
-  token: take
-  acme:
-    email: fake@example.com
-    production: false
-  tunnel:
-    account_id: fake
-    id: fake
-    secret: fake
-    ingress_vip: 10.10.10.252
-  ingress_vip: 10.10.10.251
-  gateway_vip: 10.10.10.253
 
 feature_gates:
   dual_stack_ipv4_first: true

--- a/.github/tests/config-talos.yaml
+++ b/.github/tests/config-talos.yaml
@@ -41,17 +41,3 @@ flux:
       enabled: false
   sops_age_public_key: $BOOTSTRAP_AGE_PUBLIC_KEY
 
-cloudflare:
-  enabled: true
-  domain: fake
-  token: take
-  acme:
-    email: fake@example.com
-    production: false
-  tunnel:
-    account_id: fake
-    id: fake
-    secret: fake
-    ingress_vip: 10.10.10.252
-  ingress_vip: 10.10.10.251
-  gateway_vip: 10.10.10.253

--- a/.taskfiles/Workstation/Taskfile.yaml
+++ b/.taskfiles/Workstation/Taskfile.yaml
@@ -52,8 +52,7 @@ tasks:
     cmds:
       - for:
           - budimanjojo/talhelper?as=talhelper&type=script
-          - cloudflare/cloudflared?as=cloudflared&type=script
-          - FiloSottile/age?as=age&type=script
+- FiloSottile/age?as=age&type=script
           - fluxcd/flux2?as=flux&type=script
           - getsops/sops?as=sops&type=script
           - jqlang/jq?as=jq&type=script

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -132,62 +132,6 @@ flux:
       #   ...
       #   -----END OPENSSH PRIVATE KEY-----
 
-#
-# (Optional) Cloudflare details - Cloudflare is used for DNS, TLS certificates and tunneling.
-#
-
-cloudflare:
-  # (Required) Disable to use a different DNS provider
-  enabled: false
-  # (Required) Cloudflare Domain
-  domain: ""
-  # (Required) Cloudflare API Token (NOT API Key)
-  #   1. Head over to Cloudflare and create a API Token by going to
-  #      https://dash.cloudflare.com/profile/api-tokens
-  #   2. Under the `API Tokens` section click the blue `Create Token` button.
-  #   3. Click the blue `Use template` button for the `Edit zone DNS` template.
-  #   4. Name your token something like `home-kubernetes`
-  #   5. Under `Permissions`, click `+ Add More` and add each permission below:
-  #      `Zone - DNS - Edit`
-  #      `Account - Cloudflare Tunnel - Read`
-  #   6. Limit the permissions to a specific account and zone resources.
-  #   7. Click the blue `Continue to Summary` button and then the blue `Create Token` button.
-  #   8. Copy the token and paste it below.
-  token: ""
-  # (Required) Optionals for Cloudflare Acme
-  acme:
-    # (Required) Any email you want to be associated with the ACME account (used for TLS certs via letsencrypt.org)
-    email: ""
-    # (Required) Use the ACME production server when requesting the wildcard certificate.
-    #   By default the ACME staging server is used. This is to prevent being rate-limited.
-    #   Update this option to `true` when you have verified the staging certificate
-    #   works and then re-run `task configure` and push your changes to Github.
-    production: false
-  # (Required) Provide LAN access to the cluster ingresses for internal ingress classes
-  # The Load balancer IP for internal ingress, choose an available IP
-  #   in your nodes host network that is NOT being used. This is announced over L2.
-  ingress_vip: ""
-  # (Required) Gateway is used for providing DNS to your cluster on LAN
-  # The Load balancer IP for k8s_gateway, choose an available IP
-  #   in your nodes host network that is NOT being used. This is announced over L2.
-  gateway_vip: ""
-  # (Required) Options for Cloudflare Tunnel
-  # 1. Authenticate cloudflared to your domain
-  #    > cloudflared tunnel login
-  # 2. Create the tunnel
-  #    > cloudflared tunnel create k8s
-  # 3. Copy the AccountTag, TunnelID, and TunnelSecret from the tunnel configuration file and paste them below
-  tunnel:
-    # (Required) Cloudflare Account ID (cat ~/.cloudflared/*.json | jq -r .AccountTag)
-    account_id: ""
-    # (Required) Cloudflared Tunnel ID (cat ~/.cloudflared/*.json | jq -r .TunnelID)
-    id: ""
-    # (Required) Cloudflared Tunnel Secret (cat ~/.cloudflared/*.json | jq -r .TunnelSecret)
-    secret: ""
-    # (Required) Provide WAN access to the cluster ingresses for external ingress classes
-    # The Load balancer IP for external ingress, choose an available IP
-    #   in your nodes host network that is NOT being used. This is announced over L2.
-    ingress_vip: ""
 
 # (Optional) Feature gates are used to enable experimental features
 feature_gates:


### PR DESCRIPTION
## Summary
- Removes `cloudflare:` config block from `config.sample.yaml` and all three test configs
- Drops `cloudflared` binary from Workstation Taskfile and devcontainer install script
- Not using Cloudflare tunnels, DNS provider, or ACME — no active cluster resources affected

## What was kept
- `1.1.1.1` / `1.0.0.1` public DNS references (no account or integration needed)
- `time.cloudflare.com` NTP in talconfig (public NTP, same posture)
- `cloudflare-dns.com` TLS subject name in VPN DNS configmap (cert for DoT to 1.1.1.1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)