### PR TITLE
fix(immich): correct managed role name to immich, add superuser

### DIFF
--- a/kubernetes/apps/default/immich/app/database/cluster.yaml
+++ b/kubernetes/apps/default/immich/app/database/cluster.yaml
@@ -61,9 +61,10 @@ spec:
           key: minio_s3_secret_access_key
   managed:
     roles:
-      - name: app
+      - name: immich
         ensure: present
         login: true
+        superuser: true
         passwordSecret:
           name: immich-pg-secret
   bootstrap:


### PR DESCRIPTION
## Summary

- Fixes managed role name from `app` to `immich` — the Bitwarden `pg_username` is `immich`, not `app`
- Adds `superuser: true` so the `immich` role can access the `app` database (which was created owned by `app` during initdb)
- CNPG reconciles this in-place — no cluster deletion needed

## Why

After PR #1079 landed, Immich was still failing with `password authentication failed for user "immich"`. The `managed.roles` block was managing a role named `app`, but the actual username in Bitwarden is `immich`. CNPG created the `app` user and synced its password, but Immich was connecting as `immich` (from `immich-pg-secret`) which had no managed password.

🤖 Generated with [Claude Code](https://claude.com/claude-code)