### PR TITLE
fix(immich): rename initdb database and owner from app to immich

### DIFF
--- a/kubernetes/apps/default/immich/app/database/cluster.yaml
+++ b/kubernetes/apps/default/immich/app/database/cluster.yaml
@@ -69,7 +69,7 @@ spec:
           name: immich-pg-secret
   bootstrap:
     initdb:
-      database: app
-      owner: app
+      database: immich
+      owner: immich
       postInitApplicationSQL:
         - CREATE EXTENSION IF NOT EXISTS "vectors";


### PR DESCRIPTION
## Summary

- Changes `bootstrap.initdb.database` from `app` to `immich`
- Changes `bootstrap.initdb.owner` from `app` to `immich`

## Why

The Immich backup restore fails with:
```
NOTICE: database "immich" does not exist, skipping
\connect: FATAL: password authentication failed for user "immich"
```

The pg_dumpall backup was taken when the database was named `immich`. The current cluster initialized with `database: app`, so the restore can't connect after role setup. Aligning the database name with the backup fixes the restore path.

The `immich-database-app` secret (which helmreleases reference for `DB_DATABASE_NAME`) is always named `<cluster>-app` by CNPG regardless of the actual database name — its `dbname` field will now contain `immich` instead of `app`. No helmrelease changes needed.

## Steps after merging

```bash
kubectl delete cluster immich-database -n default
kubectl delete pvc -n default -l 'cnpg.io/cluster=immich-database'
# Let Flux reconcile, wait for cluster Healthy, then retry Immich restore
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)