### PR TITLE
docs(kubernetes): document apps by namespace hierarchy

### DIFF
--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -1,0 +1,15 @@
+# kubernetes
+
+Everything under this directory is reconciled onto the cluster by [Flux](https://fluxcd.io/).
+A push to the tracked branch is what changes cluster state — `kubectl apply` is not part
+of the workflow.
+
+| Directory | Contents |
+| --- | --- |
+| [apps](./apps/README.md) | All applications, grouped by namespace. Start here for an overview of what is installed and where. |
+| [flux](./flux) | The Flux GitOps engine itself — `GitRepository`/`OCIRepository`/`HelmRepository` sources, cluster settings and secrets, and the root `Kustomization`s. |
+| [talos](./talos/README.md) | Talos Linux machine config and factory image customizations. |
+| [templates](./templates) | Shared manifest templates used across apps. |
+
+For the apps themselves, see [`apps/README.md`](./apps/README.md), which links to a
+per-namespace README listing each app with a short description and a link to its manifest.

--- a/kubernetes/apps/README.md
+++ b/kubernetes/apps/README.md
@@ -1,0 +1,36 @@
+# apps
+
+Every application reconciled onto the cluster by Flux, organized by namespace. Each app
+follows the bjw-s pattern:
+
+```text
+kubernetes/apps/<namespace>/<app>/
+├── ks.yaml                     # Flux Kustomization that points at app/
+└── app/
+    ├── helmrelease.yaml        # the HelmRelease (usually the app-template chart)
+    └── kustomization.yaml      # resources for the app
+```
+
+Each `<namespace>/kustomization.yaml` lists its apps' `ks.yaml` files, and Flux walks
+the tree from there. See each namespace's own `README.md` for the apps it contains.
+
+| Namespace | Purpose |
+| --- | --- |
+| [actions-runner-system](./actions-runner-system/README.md) | Self-hosted GitHub Actions runners. |
+| [cert-manager](./cert-manager/README.md) | TLS certificate issuance and renewal. |
+| [database](./database/README.md) | PostgreSQL and Redis-compatible datastores. |
+| [default](./default/README.md) | User-facing apps and home services. |
+| [downloads](./downloads/README.md) | Media downloaders routed through the VPN. |
+| [external-secrets](./external-secrets/README.md) | Syncs secrets from Bitwarden. |
+| [flux-system](./flux-system/README.md) | Cluster-side Flux extensions (webhooks). |
+| [games](./games/README.md) | Game servers. |
+| [kube-system](./kube-system/README.md) | Core cluster components (DNS, CSI, metrics). |
+| [network](./network/README.md) | CNI and low-level pod networking. |
+| [networking](./networking/README.md) | Ingress controllers and DNS. |
+| [observability](./observability/README.md) | Metrics, logs, dashboards, monitoring. |
+| [openebs-system](./openebs-system/README.md) | Local node-disk persistent storage. |
+| [security](./security/README.md) | Authentication and SSO (Authentik). |
+| [storage](./storage/README.md) | Object storage (MinIO). |
+| [system](./system/README.md) | Cluster-wide utilities and add-ons. |
+| [system-upgrade](./system-upgrade/README.md) | Automated node OS upgrades. |
+| [vpn](./vpn/README.md) | VPN egress gateway and DNS. |

--- a/kubernetes/apps/actions-runner-system/README.md
+++ b/kubernetes/apps/actions-runner-system/README.md
@@ -1,0 +1,10 @@
+# actions-runner-system
+
+Self-hosted [GitHub Actions](https://github.com/actions/actions-runner-controller)
+runners so this repo's workflows can execute inside the cluster. This namespace uses a
+single [`ks.yaml`](./ks.yaml) that wires up both apps below.
+
+| App | Description | Manifest |
+| --- | --- | --- |
+| [actions-runner-controller](https://github.com/actions/actions-runner-controller) | Controller (`gha-runner-scale-set-controller`) that manages ephemeral self-hosted runners. | [kustomization.yaml](./actions-runner-controller/kustomization.yaml) |
+| [runner-scale-set](https://github.com/actions/actions-runner-controller) | The `gha-runner-scale-set` (`home-ops-runner`) that spins up runner pods to execute workflows. | [kustomization.yaml](./runner-scale-set/kustomization.yaml) |

--- a/kubernetes/apps/cert-manager/README.md
+++ b/kubernetes/apps/cert-manager/README.md
@@ -1,0 +1,8 @@
+# cert-manager
+
+Issues and renews the TLS certificates used across the cluster.
+
+| App | Description | Manifest |
+| --- | --- | --- |
+| [cert-manager](https://cert-manager.io/) | Requests, issues, and renews X.509 certificates (e.g. via ACME / Let's Encrypt). | [ks.yaml](./cert-manager/ks.yaml) |
+| [addons](https://github.com/jokajak/cert-manager-webhook-henet) | ACME DNS-01 solver webhook for Hurricane Electric (`dns.he.net`), enabling DNS-validated certificates. | [ks.yaml](./addons/ks.yaml) |

--- a/kubernetes/apps/database/README.md
+++ b/kubernetes/apps/database/README.md
@@ -1,14 +1,9 @@
 # database
-This directory contains the applications that provide database services throughout the cluster.
 
-## cloudnative-pg
+Database services consumed by applications throughout the cluster.
 
-[cloudnative-pg](https://cloudnative-pg.io/) provides a postgres service within the cluster usable by applications.
-
-* [cnpg.yaml](./cloudnative-pg/ks.yaml)
-
-## dragonfly
-
-[dragonfly](https://www.dragonflydb.io/) is an alternative to redis and provides better resource utilization.
-
-* [dragonfly.yaml](./dragonfly/ks.yaml)
+| App | Description | Manifest |
+| --- | --- | --- |
+| [cloudnative-pg](https://cloudnative-pg.io/) | PostgreSQL operator that provisions and manages in-cluster Postgres clusters. | [ks.yaml](./cloudnative-pg/ks.yaml) |
+| [cnpg-barman-plugin](https://github.com/cloudnative-pg/plugin-barman-cloud) | Barman Cloud plugin for CloudNativePG — WAL archiving and backups to object storage (MinIO). | [ks.yaml](./cnpg-barman-plugin/ks.yaml) |
+| [dragonfly](https://www.dragonflydb.io/) | Redis-compatible in-memory datastore (deployed via its operator) with better resource utilization than Redis. | [ks.yaml](./dragonfly/ks.yaml) |

--- a/kubernetes/apps/default/README.md
+++ b/kubernetes/apps/default/README.md
@@ -1,48 +1,16 @@
-# default namespace applications
+# default
 
-This directory contains all of the applications deployed to the `default`
-namespace.
+User-facing applications and home services deployed to the `default` namespace.
 
-## authentik
-
-[authentik](https://goauthentik.io/) is used to provide authorization and SSO capabilities for services. The intention
-is to use external credentials like google accounts or github accounts for authentication and authentik local or
-application local groups for authorization.
-
-* [authentik.yaml](./authentik/ks.yaml)
-
-The authentik configuration is stored as IaC using [terraform](../../../terraform/authentik/README.md)
-
-## frigate
-
-![image of frigate](https://i.imgur.com/hv7bh6m.png)
-
-Installs [frigate](https://github.com/blakeblackshear/frigate/): Realtime object detection on RTSP cameras with the Google Coral
-
-* [frigate](frigate/app/helmrelease.yaml)
-
-## home-assistant
-
-[home-assistant](https://www.home-assistant.io/) provides home automation services.
-
-* [homeassistant.yaml](./home-assistant/ks.yaml)
-
-## immich
-
-[immich](https://github.com/immich-app/immich) is used to backup photos.
-
-* [immich.yaml](./immich/ks.yaml)
-
-## unifi
-
-[ubiquiti unifi controller](https://github.com/jacobalberty/unifi-docker) for
-wireless access points and home networking
-
-* [unifi.yaml](./unifi/ks.yaml)
-
-## zwave-js-ui
-
-[zwave-js-ui](https://zwave-js.github.io/zwave-js-ui/#/) is used to manage the zwave devices. zwave is a wireless
-protocol used for IoT.
-
-* [zwavejs.yaml](./zwave-js-ui/ks.yaml)
+| App | Description | Manifest |
+| --- | --- | --- |
+| [calibre](https://calibre-ebook.com/) | E-book library management and conversion. | [ks.yaml](./calibre/ks.yaml) |
+| [esphome](https://esphome.io/) | Builds and manages firmware for ESP-based IoT devices. | [ks.yaml](./esphome/ks.yaml) |
+| [home-assistant](https://www.home-assistant.io/) | Home automation hub. | [ks.yaml](./home-assistant/ks.yaml) |
+| [home-assistant-matter-hub](https://github.com/t0bst4r/home-assistant-matter-hub) | Bridges Home Assistant entities to the Matter smart-home protocol. | [ks.yaml](./home-assistant-matter-hub/ks.yaml) |
+| [immich](https://immich.app/) | Self-hosted photo and video backup (server, microservices, and machine-learning components). | [ks.yaml](./immich/ks.yaml) |
+| [jellyfin](https://jellyfin.org/) | Media server for movies, shows, and music. | [ks.yaml](./jellyfin/ks.yaml) |
+| [mealie](https://mealie.io/) | Recipe manager and meal planner. | [ks.yaml](./mealie/ks.yaml) |
+| [unifi](https://github.com/jacobalberty/unifi-docker) | Ubiquiti UniFi controller for wireless access points and home networking. | [ks.yaml](./unifi/ks.yaml) |
+| [wallos](https://github.com/ellite/Wallos) | Subscription and recurring-payment tracker. | [ks.yaml](./wallos/ks.yaml) |
+| [zwave-js-ui](https://zwave-js.github.io/zwave-js-ui/) | Manages Z-Wave IoT devices over the Z-Wave wireless protocol. | [ks.yaml](./zwave-js-ui/ks.yaml) |

--- a/kubernetes/apps/downloads/README.md
+++ b/kubernetes/apps/downloads/README.md
@@ -1,0 +1,9 @@
+# downloads
+
+Media-download applications. Traffic egresses through the VPN gateway in the
+[`vpn`](../vpn/README.md) namespace.
+
+| App | Description | Manifest |
+| --- | --- | --- |
+| [metube](https://github.com/alexta69/metube) | Web UI for `yt-dlp` to download video/audio from the web. | [ks.yaml](./metube/ks.yaml) |
+| [qbittorrent](https://www.qbittorrent.org/) | BitTorrent client, routed through the VPN gateway pod. | [ks.yaml](./qbittorrent/ks.yaml) |

--- a/kubernetes/apps/external-secrets/README.md
+++ b/kubernetes/apps/external-secrets/README.md
@@ -1,0 +1,8 @@
+# external-secrets
+
+Bridges the cluster to the external secret manager so manifests reference only secret
+*names*, never values.
+
+| App | Description | Manifest |
+| --- | --- | --- |
+| [external-secrets](https://external-secrets.io/) | External Secrets Operator — syncs secrets from Bitwarden into Kubernetes `Secret`s via the `bitwarden-login` / `bitwarden-fields` `ClusterSecretStore`s. | [ks.yaml](./external-secrets/ks.yaml) |

--- a/kubernetes/apps/flux-system/README.md
+++ b/kubernetes/apps/flux-system/README.md
@@ -1,0 +1,8 @@
+# flux-system
+
+Cluster-side extensions to the Flux GitOps engine. The core Flux components live under
+[`kubernetes/flux`](../../flux); this namespace adds the pieces that run as cluster apps.
+
+| App | Description | Manifest |
+| --- | --- | --- |
+| [webhooks](https://fluxcd.io/flux/guides/webhook-receivers/) | GitHub webhook `Receiver` so pushes trigger immediate Flux reconciliation instead of waiting for the poll interval. | [ks.yaml](./webhooks/ks.yaml) |

--- a/kubernetes/apps/games/README.md
+++ b/kubernetes/apps/games/README.md
@@ -1,12 +1,9 @@
-# games namespace applications
+# games
 
-This directory contains all of the applications deployed to the `games`
-namespace. This namespace was created so that applications can be easily
-identified.
+Game servers, grouped into their own namespace so they can be easily identified.
 
-## minecraft
-
-Minecraft is deployed as standard edition because bedrock is on the switch
-can't directly access the server so I'll have to use a proxy for it.
-
-* [minecraft.yaml](./minecraft/ks.yaml)
+| App | Description | Manifest |
+| --- | --- | --- |
+| [minecraft](https://github.com/itzg/docker-minecraft-server) | Minecraft Java Edition server, with [Geyser](https://geysermc.org/) so Bedrock clients (e.g. the Switch) can connect via a proxy. | [ks.yaml](./minecraft/ks.yaml) |
+| [minecraft-rcon-web](https://github.com/itzg/rcon-web-admin) | Web admin panel for the Minecraft server over RCON. | [ks.yaml](./minecraft-rcon-web/ks.yaml) |
+| [minecraft-router](https://github.com/itzg/mc-router) | Routes incoming connections to the correct Minecraft backend by hostname. | [ks.yaml](./minecraft-router/ks.yaml) |

--- a/kubernetes/apps/kube-system/README.md
+++ b/kubernetes/apps/kube-system/README.md
@@ -1,24 +1,12 @@
 # kube-system
 
-This directory contains the applications running in the kube-system namespace.
+Core cluster components that run in the `kube-system` namespace. They are packaged as
+apps here so their configuration can be managed in Git.
 
-## coredns
-
-[coredns](https://coredns.io/) provides dns for the cluster. It's included as an app so that the configuration can be
-modified
-
-* [coredns](./coredns/ks.yaml)
-
-## descheduler
-
-[descheduler](https://github.com/kubernetes-sigs/descheduler) will evict pods to force the cluster to rebalance.
-
-* [descheduler](./descheduler/ks.yaml)
-
-## node-feature-discovery
-
-[node-feature-discovery](https://github.com/kubernetes-sigs/node-feature-discovery) provides annotations for nodes to
-support node selection for deployments. It is mostly used for tagging nodes with custom devices attached like a
-HomeAssistant SkyConnect
-
-* [node-feature-discover](./node-feature-discovery/ks.yaml)
+| App | Description | Manifest |
+| --- | --- | --- |
+| [coredns](https://coredns.io/) | In-cluster DNS; managed as an app so the config can be customized. | [ks.yaml](./coredns/ks.yaml) |
+| [csi-driver-nfs](https://github.com/kubernetes-csi/csi-driver-nfs) | CSI driver that mounts NFS shares (the NAS) as PersistentVolumes. | [ks.yaml](./csi-driver-nfs/ks.yaml) |
+| [kubelet-csr-approver](https://github.com/postfinance/kubelet-csr-approver) | Automatically approves kubelet serving-certificate CSRs. | [ks.yaml](./kubelet-csr-approver/ks.yaml) |
+| [metrics-server](https://github.com/kubernetes-sigs/metrics-server) | Resource metrics API for `kubectl top` and the Horizontal Pod Autoscaler. | [ks.yaml](./metrics-server/ks.yaml) |
+| [node-feature-discovery](https://github.com/kubernetes-sigs/node-feature-discovery) | Labels nodes with hardware features for scheduling (e.g. nodes with a Home Assistant SkyConnect). | [ks.yaml](./node-feature-discovery/ks.yaml) |

--- a/kubernetes/apps/network/README.md
+++ b/kubernetes/apps/network/README.md
@@ -1,0 +1,11 @@
+# network
+
+Low-level cluster networking: the CNI and the plumbing for additional pod interfaces.
+(Application-facing ingress/DNS lives in [`networking`](../networking/README.md).)
+
+| App | Description | Manifest |
+| --- | --- | --- |
+| [cilium](https://cilium.io/) | eBPF-based CNI providing pod networking, load balancing, and network policy. | [ks.yaml](./cilium/ks.yaml) |
+| [multus](https://github.com/k8snetworkplumbingwg/multus-cni) | CNI meta-plugin that attaches multiple network interfaces to pods. | [ks.yaml](./multus/ks.yaml) |
+| [node-network-operator](https://github.com/solidDoWant/node-network-operator) | Declaratively manages host network links on nodes. | [ks.yaml](./node-network-operator/ks.yaml) |
+| [whereabouts](https://github.com/k8snetworkplumbingwg/whereabouts) | Cluster-wide IPAM for the secondary (Multus) networks. | [ks.yaml](./whereabouts/ks.yaml) |

--- a/kubernetes/apps/networking/README.md
+++ b/kubernetes/apps/networking/README.md
@@ -1,0 +1,11 @@
+# networking
+
+Application-facing networking: ingress controllers and DNS. (The CNI and low-level pod
+networking live in [`network`](../network/README.md).)
+
+| App | Description | Manifest |
+| --- | --- | --- |
+| [echo-server](https://github.com/mendhak/docker-http-https-echo) | Simple HTTP echo service for testing ingress and routing. | [ks.yaml](./echo-server/ks.yaml) |
+| [external-dns](https://github.com/kubernetes-sigs/external-dns) | Syncs ingress/service hostnames to the upstream DNS provider (Pi-hole). | [ks.yaml](./external-dns/ks.yaml) |
+| [k8s-gateway](https://github.com/ori-edge/k8s_gateway) | DNS server that answers for in-cluster ingress hostnames. | [ks.yaml](./k8s-gateway/ks.yaml) |
+| [nginx](https://github.com/kubernetes/ingress-nginx) | ingress-nginx controllers (`internal` and `external`) that terminate HTTP ingress. | [ks.yaml](./nginx/ks.yaml) |

--- a/kubernetes/apps/observability/README.md
+++ b/kubernetes/apps/observability/README.md
@@ -1,9 +1,13 @@
-# Observability
+# observability
 
-This directory contains applications related to Observability.
+Metrics, logs, dashboards, and health monitoring for the cluster and home network.
 
-## vector
-
-Using [vector](https://github.com/vectordotdev/vector) instead of promtail to feed logs to loki.
-
-* [vector/](vector)
+| App | Description | Manifest |
+| --- | --- | --- |
+| [gatus](https://github.com/TwiN/gatus) | Uptime/health status dashboard for services. | [ks.yaml](./gatus/ks.yaml) |
+| [goflow2](https://github.com/netsampler/goflow2) | NetFlow/sFlow/IPFIX collector for network-flow telemetry. | [ks.yaml](./goflow2/ks.yaml) |
+| [grafana](https://grafana.com/) | Dashboards for metrics and logs. | [ks.yaml](./grafana/ks.yaml) |
+| [smartctl-exporter](https://github.com/prometheus-community/smartctl_exporter) | Exports S.M.A.R.T. disk-health metrics. | [ks.yaml](./smartctl-exporter/ks.yaml) |
+| [unpoller](https://github.com/unpoller/unpoller) | Exports UniFi controller metrics. | [ks.yaml](./unpoller/ks.yaml) |
+| [vector](https://vector.dev/) | Log/metric collection pipeline (agent + aggregator) that feeds Loki — used instead of promtail. | [ks.yaml](./vector/ks.yaml) |
+| [victoriametrics](https://victoriametrics.com/) | Metrics storage and the VictoriaMetrics k8s stack (used in place of Prometheus). | [ks.yaml](./victoriametrics/ks.yaml) |

--- a/kubernetes/apps/openebs-system/README.md
+++ b/kubernetes/apps/openebs-system/README.md
@@ -1,0 +1,7 @@
+# openebs-system
+
+Local (node-attached) persistent storage for the cluster.
+
+| App | Description | Manifest |
+| --- | --- | --- |
+| [openebs](https://openebs.io/) | Provides the `openebs-hostpath` storage class for ephemeral/local PVCs backed by node disk. | [ks.yaml](./openebs/ks.yaml) |

--- a/kubernetes/apps/security/README.md
+++ b/kubernetes/apps/security/README.md
@@ -1,0 +1,10 @@
+# security
+
+Authentication and authorization for cluster services.
+
+| App | Description | Manifest |
+| --- | --- | --- |
+| [authentik](https://goauthentik.io/) | Identity provider / SSO. Federates external accounts (Google, GitHub) for authentication and uses Authentik or app-local groups for authorization. | [ks.yaml](./authentik/ks.yaml) |
+
+Authentik's objects (providers, applications, flows) are managed as IaC with OpenTofu —
+see [`terraform/authentik`](../../../terraform/authentik/README.md).

--- a/kubernetes/apps/storage/README.md
+++ b/kubernetes/apps/storage/README.md
@@ -1,14 +1,11 @@
 # storage
 
-This namespace is used for providing storage related services.
+Storage-related services for the cluster.
 
-## minio
+| App | Description | Manifest |
+| --- | --- | --- |
+| [minio](https://min.io/) | S3-compatible object storage. | [ks.yaml](./minio/ks.yaml) |
 
-[minio](https://github.com/minio/minio) provides s3 like storage.
-
-S3 storage is used by restic with volsync to provide backup and restore capability for volumes that are stored on local
-disks instead of the NAS.
-
-Some services are IO sensitive and therefore benefit from being stored on a local disk instead of on an NFS share.
-
-* [minio.yaml](./minio/ks.yaml)
+MinIO backs restic/volsync backups for volumes kept on local disk (rather than the NAS)
+and stores CNPG Postgres backups. Some services are IO-sensitive and benefit from local
+disk instead of an NFS share, so object storage gives them a backup/restore path.

--- a/kubernetes/apps/system-upgrade/README.md
+++ b/kubernetes/apps/system-upgrade/README.md
@@ -1,0 +1,8 @@
+# system-upgrade
+
+Automated, Git-driven node OS upgrades.
+
+| App | Description | Manifest |
+| --- | --- | --- |
+| [system-upgrade-controller](https://github.com/rancher/system-upgrade-controller) | Orchestrates node upgrades by reconciling `Plan` resources. | [ks.yaml](./system-upgrade-controller/ks.yaml) |
+| [talos](https://www.talos.dev/) | The `Plan` that upgrades Talos Linux on the nodes via the controller. | [ks.yaml](./talos/ks.yaml) |

--- a/kubernetes/apps/system/README.md
+++ b/kubernetes/apps/system/README.md
@@ -1,0 +1,10 @@
+# system
+
+Cluster-wide utilities and operational add-ons.
+
+| App | Description | Manifest |
+| --- | --- | --- |
+| [descheduler](https://github.com/kubernetes-sigs/descheduler) | Evicts pods to force the scheduler to rebalance the cluster. | [ks.yaml](./descheduler/ks.yaml) |
+| [generic-device-plugin](https://github.com/squat/generic-device-plugin) | Exposes host devices (e.g. USB) to pods as schedulable resources. | [ks.yaml](./generic-device-plugin/ks.yaml) |
+| [reloader](https://github.com/stakater/Reloader) | Restarts workloads when their `ConfigMap`/`Secret` changes. | [ks.yaml](./reloader/ks.yaml) |
+| [spegel](https://github.com/spegel-org/spegel) | Stateless, cluster-local OCI registry mirror for peer-to-peer image pulls. | [ks.yaml](./spegel/ks.yaml) |

--- a/kubernetes/apps/vpn/README.md
+++ b/kubernetes/apps/vpn/README.md
@@ -1,0 +1,13 @@
+# vpn
+
+A VPN egress gateway and its DNS, so selected workloads (e.g. the
+[`downloads`](../downloads/README.md) apps) can route their traffic through a VPN. The
+namespace uses an internal `192.168.24.0/24` overlay with fixed pod IPs.
+
+| App | Description | Manifest |
+| --- | --- | --- |
+| [gateway](https://github.com/qdm12/gluetun) | Gluetun VPN client gateway pod; other workloads egress through it. | [ks.yaml](./gateway/ks.yaml) |
+| [dns](https://dnsdist.org/) | dnsdist resolver for the VPN namespace. | [ks.yaml](./dns/ks.yaml) |
+
+See the design doc under [`docs/plans`](../../../docs/plans) for the full VPN-gateway
+architecture.


### PR DESCRIPTION
## Summary

Standardizes the `kubernetes/` READMEs so the application hierarchy is documented consistently and accurately. Previously only 8 READMEs existed (out of 18 namespaces), and several were stale.

## Changes

**Top-level overviews (new)**
- `kubernetes/README.md` — points at `apps/`, `flux/`, `talos/`, `templates/`
- `kubernetes/apps/README.md` — explains the bjw-s `ks.yaml` + `app/` layout and indexes all 18 namespaces

**Namespace READMEs**
- **12 created** for namespaces that had none: actions-runner-system, cert-manager, downloads, external-secrets, flux-system, network, networking, openebs-system, security, system, system-upgrade, vpn
- **6 rewritten** to match current reality: `default` (dropped removed `frigate` and relocated `authentik`; added calibre/esphome/jellyfin/mealie/wallos/matter-hub), `kube-system` (dropped relocated `descheduler`; added csi-driver-nfs/metrics-server/kubelet-csr-approver), `observability` (was vector-only → all 7 apps), plus `database`, `games`, `storage`

Each namespace README uses a uniform format: a one-line purpose + a summary table (**App | Description | Manifest link**), with descriptions/links derived from each app's HelmRelease. Useful prose (MinIO backup rationale, Authentik→`terraform/authentik` IaC cross-ref, games/VPN notes) is preserved.

## Notes

- Docs-only; no manifest changes.
- No real network details committed — the VPN `192.168.24.0/24` overlay is the only address mentioned (explicitly allowed by `CLAUDE.md`).

## Verification

- All relative links (`./` and `../`) resolve.
- No trailing whitespace; all files end with a newline.
- `pre-commit` isn't installed in the container, so its whitespace/EOF checks were run manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016vbBntui3SQWFheEgQbhGz)_