### PR TITLE
feat(wallos): integrate Authentik OIDC SSO

### DIFF
--- a/kubernetes/apps/productivity/wallos/app/externalsecret.yaml
+++ b/kubernetes/apps/productivity/wallos/app/externalsecret.yaml
@@ -1,0 +1,28 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.ok8.sh/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: wallos
+  namespace: productivity
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: bitwarden-login
+  target:
+    name: wallos-secrets
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        OIDC_CLIENT_ID: "{{ .client_id }}"
+        OIDC_CLIENT_SECRET: "{{ .client_secret }}"
+  data:
+    - secretKey: client_id
+      remoteRef:
+        key: authentik-client-wallos
+        property: username
+    - secretKey: client_secret
+      remoteRef:
+        key: authentik-client-wallos
+        property: password

--- a/kubernetes/apps/productivity/wallos/app/helm-release.yaml
+++ b/kubernetes/apps/productivity/wallos/app/helm-release.yaml
@@ -39,6 +39,16 @@ spec:
               tag: 4.9.5
             env:
               TZ: ${TIMEZONE:=US}
+              OIDC_PROVIDER_LABEL: Authentik
+              OIDC_AUTH_URL: https://auth.${SECRET_DOMAIN}/application/o/authorize/
+              OIDC_TOKEN_URL: https://auth.${SECRET_DOMAIN}/application/o/token/
+              OIDC_USER_URL: https://auth.${SECRET_DOMAIN}/application/o/userinfo/
+              OIDC_END_SESSION_URL: https://auth.${SECRET_DOMAIN}/application/o/wallos-provider/end-session/
+              OIDC_REDIRECT_URI: https://subs.${SECRET_DOMAIN}/api/oidc/callback
+              OIDC_SCOPES: openid profile email
+            envFrom:
+              - secretRef:
+                  name: wallos-secrets
             resources:
               requests:
                 cpu: 50m

--- a/kubernetes/apps/productivity/wallos/app/kustomization.yaml
+++ b/kubernetes/apps/productivity/wallos/app/kustomization.yaml
@@ -2,5 +2,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./externalsecret.yaml
   - ./helm-release.yaml
   - ../../../../templates/gatus/guarded

--- a/terraform/authentik/application_wallos.tf
+++ b/terraform/authentik/application_wallos.tf
@@ -1,0 +1,57 @@
+## -----------------------------------------------------------------------------
+## Authentik Application - Wallos
+## These are resources for wallos to use authentik for SSO
+## -----------------------------------------------------------------------------
+
+## ----------------------------------------
+## Wallos - Authentication (authn) resources
+## ----------------------------------------
+module "wallos_oidc_creds" {
+  source          = "./oidc_creds"
+  application     = "wallos"
+  organization_id = var.organization_id
+  collection_id   = var.collection_id
+}
+
+resource "authentik_provider_oauth2" "wallos_oauth" {
+  name = "wallos-provider"
+
+  client_id     = module.wallos_oidc_creds.client_id
+  client_secret = module.wallos_oidc_creds.client_secret
+
+  authorization_flow = resource.authentik_flow.provider-authorization-implicit-consent.uuid
+  invalidation_flow  = resource.authentik_flow.invalidation.uuid
+
+  property_mappings = data.authentik_property_mapping_provider_scope.oauth2.ids
+
+  access_token_validity = "hours=8"
+
+  allowed_redirect_uris = [
+    {
+      matching_mode     = "strict",
+      redirect_uri_type = "authorization",
+      url               = "https://subs.${var.domain}/api/oidc/callback"
+    }
+  ]
+
+}
+
+resource "authentik_application" "wallos_application" {
+  name               = "Wallos"
+  slug               = authentik_provider_oauth2.wallos_oauth.name
+  protocol_provider  = authentik_provider_oauth2.wallos_oauth.id
+  open_in_new_tab    = true
+  meta_icon          = "https://raw.githubusercontent.com/walkxcode/dashboard-icons/main/png/wallos.png"
+  meta_launch_url    = "https://subs.${var.domain}"
+  policy_engine_mode = "any"
+}
+
+## ----------------------------------------
+## Wallos - Authorization (authz) resources
+## ----------------------------------------
+# All users can access Wallos
+resource "authentik_policy_binding" "wallos_users" {
+  target = authentik_application.wallos_application.uuid
+  group  = authentik_group.users.id
+  order  = 0
+}


### PR DESCRIPTION
- Add terraform/authentik/application_wallos.tf: OAuth2 provider,
  Authentik application, and policy binding granting the users group
  access (mirrors the Immich pattern)
- Add kubernetes/apps/productivity/wallos/app/externalsecret.yaml:
  pulls client_id/secret from Bitwarden item authentik-client-wallos
- Update helm-release.yaml: inject OIDC env vars (endpoints, scopes,
  redirect URI) and mount wallos-secrets via envFrom
- Update kustomization.yaml: reference the new ExternalSecret

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Bs8bnzbCtrK9S2WQiWrgda