### PR TITLE
feat(ai): add Open WebUI with Authentik SSO

### DIFF
--- a/kubernetes/apps/ai/kustomization.yaml
+++ b/kubernetes/apps/ai/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./namespace.yaml
+  - ./open-webui/ks.yaml

--- a/kubernetes/apps/ai/namespace.yaml
+++ b/kubernetes/apps/ai/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ai
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/apps/ai/open-webui/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/open-webui/app/externalsecret.yaml
@@ -1,0 +1,28 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.ok8.sh/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: open-webui
+  namespace: ai
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: bitwarden-login
+  target:
+    name: open-webui-secret
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        OAUTH_CLIENT_ID: "{{ .client_id }}"
+        OAUTH_CLIENT_SECRET: "{{ .client_secret }}"
+  data:
+    - secretKey: client_id
+      remoteRef:
+        key: authentik-client-open-webui
+        property: username
+    - secretKey: client_secret
+      remoteRef:
+        key: authentik-client-open-webui
+        property: password

--- a/kubernetes/apps/ai/open-webui/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/open-webui/app/helmrelease.yaml
@@ -1,0 +1,83 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2beta2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: open-webui
+spec:
+  interval: 15m
+  chart:
+    spec:
+      chart: app-template
+      version: 3.7.3
+      sourceRef:
+        kind: HelmRepository
+        name: bjw-s
+        namespace: flux-system
+      interval: 15m
+  install:
+    remediation:
+      retries: 5
+  upgrade:
+    remediation:
+      retries: 5
+  values:
+    controllers:
+      open-webui:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          main:
+            image:
+              repository: ghcr.io/open-webui/open-webui
+              tag: v0.9.6
+            env:
+              # OAuth / Authentik SSO
+              ENABLE_OAUTH_SIGNUP: "true"
+              ENABLE_OAUTH_PERSISTENT_CONFIG: "false"
+              OAUTH_MERGE_ACCOUNTS_BY_EMAIL: "true"
+              OAUTH_PROVIDER_NAME: Login
+              OPENID_PROVIDER_URL: "https://auth.${SECRET_DOMAIN:=example.com}/application/o/open-webui/.well-known/openid-configuration"
+              OAUTH_SCOPES: "openid email profile"
+              OPENID_REDIRECT_URI: "https://chat.${SECRET_DOMAIN:=example.com}/oauth/oidc/callback"
+              # WebSocket support (shared Dragonfly Redis)
+              ENABLE_WEBSOCKET_SUPPORT: "true"
+              WEBSOCKET_MANAGER: redis
+              WEBSOCKET_REDIS_URL: "redis://dragonfly.database.svc.cluster.local.:6379"
+            envFrom:
+              - secretRef:
+                  name: open-webui-secret
+            resources:
+              requests:
+                cpu: 100m
+                memory: 512Mi
+              limits:
+                memory: 2Gi
+    service:
+      main:
+        controller: open-webui
+        ports:
+          http:
+            port: 8080
+    ingress:
+      main:
+        enabled: true
+        className: internal
+        hosts:
+          - host: &host "chat.${SECRET_DOMAIN:=example.com}"
+            paths:
+              - path: /
+                pathType: Prefix
+                service:
+                  identifier: main
+                  port: http
+        tls:
+          - hosts:
+              - *host
+            secretName: wildcard-cert-tls
+    persistence:
+      data:
+        enabled: true
+        existingClaim: open-webui-data
+        globalMounts:
+          - path: /app/backend/data

--- a/kubernetes/apps/ai/open-webui/app/kustomization.yaml
+++ b/kubernetes/apps/ai/open-webui/app/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: ai
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./pvc.yaml

--- a/kubernetes/apps/ai/open-webui/app/pvc.yaml
+++ b/kubernetes/apps/ai/open-webui/app/pvc.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: open-webui-data
+  namespace: ai
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: openebs-hostpath
+  resources:
+    requests:
+      storage: 5Gi

--- a/kubernetes/apps/ai/open-webui/ks.yaml
+++ b/kubernetes/apps/ai/open-webui/ks.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cluster-apps-open-webui
+  namespace: flux-system
+spec:
+  path: ./kubernetes/apps/ai/open-webui/app
+  sourceRef:
+    kind: GitRepository
+    name: home-kubernetes
+  interval: 30m
+  retryInterval: 5m
+  timeout: 10m
+  prune: true
+  wait: true
+  dependsOn:
+    - name: cluster-apps-external-secrets
+    - name: dragonfly-cluster

--- a/terraform/authentik/application_openwebui.tf
+++ b/terraform/authentik/application_openwebui.tf
@@ -1,0 +1,57 @@
+## -----------------------------------------------------------------------------
+## Authentik Application - Open WebUI
+## These are resources for open-webui to use authentik for SSO
+## -----------------------------------------------------------------------------
+
+## ----------------------------------------
+## Open WebUI - Authentication (authn) resources
+## ----------------------------------------
+module "openwebui_oidc_creds" {
+  source          = "./oidc_creds"
+  application     = "open-webui"
+  organization_id = var.organization_id
+  collection_id   = var.collection_id
+}
+
+resource "authentik_provider_oauth2" "openwebui_oauth" {
+  name = "open-webui-provider"
+
+  client_id     = module.openwebui_oidc_creds.client_id
+  client_secret = module.openwebui_oidc_creds.client_secret
+
+  authorization_flow = resource.authentik_flow.provider-authorization-implicit-consent.uuid
+  invalidation_flow  = resource.authentik_flow.invalidation.uuid
+
+  property_mappings = data.authentik_property_mapping_provider_scope.oauth2.ids
+
+  access_token_validity = "hours=8"
+
+  allowed_redirect_uris = [
+    {
+      matching_mode     = "strict",
+      redirect_uri_type = "authorization",
+      url               = "https://chat.${var.domain}/oauth/oidc/callback"
+    }
+  ]
+
+}
+
+resource "authentik_application" "openwebui_application" {
+  name               = "Open WebUI"
+  slug               = authentik_provider_oauth2.openwebui_oauth.name
+  protocol_provider  = authentik_provider_oauth2.openwebui_oauth.id
+  group              = authentik_group.home.name
+  open_in_new_tab    = true
+  meta_icon          = "https://raw.githubusercontent.com/open-webui/open-webui/refs/heads/main/static/favicon.png"
+  meta_launch_url    = "https://chat.${var.domain}"
+  policy_engine_mode = "any"
+}
+
+## ----------------------------------------
+## Open WebUI - Authorization (authz) resources
+## ----------------------------------------
+resource "authentik_policy_binding" "openwebui_users" {
+  target = authentik_application.openwebui_application.uuid
+  group  = authentik_group.users.id
+  order  = 0
+}


### PR DESCRIPTION
Deploys Open WebUI in a new `ai` namespace, integrated with Authentik
for single sign-on via OAuth2/OIDC. The login button reads "Login"
rather than "Authentik" for a cleaner UX.

- terraform/authentik/application_openwebui.tf: creates OAuth2 provider,
  Authentik application, and Bitwarden credentials via oidc_creds module
- kubernetes/apps/ai/: new namespace auto-discovered by cluster-apps
- open-webui HelmRelease uses bjw-s app-template v3.7.3, shared Dragonfly
  Redis for WebSocket support, openebs-hostpath PVC for data persistence
- ExternalSecret pulls OAUTH_CLIENT_ID/SECRET from Bitwarden item
  `authentik-client-open-webui` (created on `tofu apply`)

Owner action required: run `tofu apply` in terraform/authentik/ to
register the provider in Authentik and populate Bitwarden credentials.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018EVMQQFLqmvGy4MMUPUAbA