### PR TITLE
feat(open-webui): disable local sentence-transformers model download

### DIFF
--- a/kubernetes/apps/ai/open-webui/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/open-webui/app/helmrelease.yaml
@@ -40,6 +40,8 @@ spec:
               OPENID_PROVIDER_URL: "https://auth.${SECRET_DOMAIN:=example.com}/application/o/open-webui/.well-known/openid-configuration"
               OAUTH_SCOPES: "openid email profile"
               OPENID_REDIRECT_URI: "https://chat.${SECRET_DOMAIN:=example.com}/oauth/oidc/callback"
+              # Disable local sentence-transformers download; RAG not in use
+              RAG_EMBEDDING_ENGINE: "openai"
               # WebSocket support (shared Dragonfly Redis)
               ENABLE_WEBSOCKET_SUPPORT: "true"
               WEBSOCKET_MANAGER: redis


### PR DESCRIPTION
Set RAG_EMBEDDING_ENGINE to openai to prevent Open WebUI from downloading
and loading the HuggingFace sentence-transformers model at startup, since
document RAG is not in use.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BUZ525z2aJ23x5eofsnsiN