### PR TITLE
fix(kubeconform): default SECRET_DOMAIN to avoid strict envsubst failure

### DIFF
--- a/kubernetes/apps/productivity/wallos/app/helm-release.yaml
+++ b/kubernetes/apps/productivity/wallos/app/helm-release.yaml
@@ -40,11 +40,11 @@ spec:
             env:
               TZ: ${TIMEZONE:=US}
               OIDC_PROVIDER_LABEL: Authentik
-              OIDC_AUTH_URL: https://auth.${SECRET_DOMAIN}/application/o/authorize/
-              OIDC_TOKEN_URL: https://auth.${SECRET_DOMAIN}/application/o/token/
-              OIDC_USER_URL: https://auth.${SECRET_DOMAIN}/application/o/userinfo/
-              OIDC_END_SESSION_URL: https://auth.${SECRET_DOMAIN}/application/o/wallos-provider/end-session/
-              OIDC_REDIRECT_URI: https://subs.${SECRET_DOMAIN}/api/oidc/callback
+              OIDC_AUTH_URL: https://auth.${SECRET_DOMAIN:=internal}/application/o/authorize/
+              OIDC_TOKEN_URL: https://auth.${SECRET_DOMAIN:=internal}/application/o/token/
+              OIDC_USER_URL: https://auth.${SECRET_DOMAIN:=internal}/application/o/userinfo/
+              OIDC_END_SESSION_URL: https://auth.${SECRET_DOMAIN:=internal}/application/o/wallos-provider/end-session/
+              OIDC_REDIRECT_URI: https://subs.${SECRET_DOMAIN:=internal}/api/oidc/callback
               OIDC_SCOPES: openid profile email
             envFrom:
               - secretRef:

--- a/kubernetes/components/volsync/externalsecret.yaml
+++ b/kubernetes/components/volsync/externalsecret.yaml
@@ -14,7 +14,7 @@ spec:
       type: Opaque
       data:
         # restic repo per app, under the shared `backups` MinIO bucket
-        RESTIC_REPOSITORY: "s3:https://s3.${SECRET_DOMAIN}/backups/volsync/${APP}"
+        RESTIC_REPOSITORY: "s3:https://s3.${SECRET_DOMAIN:=internal}/backups/volsync/${APP}"
         RESTIC_PASSWORD: "{{ .restic_password }}"
         AWS_ACCESS_KEY_ID: "{{ .aws_access_key_id }}"
         AWS_SECRET_ACCESS_KEY: "{{ .aws_secret_access_key }}"


### PR DESCRIPTION
The wallos Authentik OIDC integration added plain ${SECRET_DOMAIN} references in the OIDC URLs. CI has no decrypted cluster-secrets, so `flux envsubst --strict` errors with "variable not set", failing the Kubeconform job (seen on PR #1105).

Add the repo-wide `:=internal` default to the 5 wallos OIDC URLs and to the latent plain reference in the volsync component's restic repo URL.