### PR TITLE
fix(kubeconform): default SECRET_DOMAIN to avoid strict envsubst failure

### DIFF
--- a/kubernetes/apps/productivity/wallos/app/helm-release.yaml
+++ b/kubernetes/apps/productivity/wallos/app/helm-release.yaml
@@ -40,11 +40,11 @@ spec:
             env:
               TZ: ${TIMEZONE:=US}
               OIDC_PROVIDER_LABEL: Authentik
-              OIDC_AUTH_URL: https://auth.${SECRET_DOMAIN}/application/o/authorize/
-              OIDC_TOKEN_URL: https://auth.${SECRET_DOMAIN}/application/o/token/
-              OIDC_USER_URL: https://auth.${SECRET_DOMAIN}/application/o/userinfo/
-              OIDC_END_SESSION_URL: https://auth.${SECRET_DOMAIN}/application/o/wallos-provider/end-session/
-              OIDC_REDIRECT_URI: https://subs.${SECRET_DOMAIN}/api/oidc/callback
+              OIDC_AUTH_URL: https://auth.${SECRET_DOMAIN:=internal}/application/o/authorize/
+              OIDC_TOKEN_URL: https://auth.${SECRET_DOMAIN:=internal}/application/o/token/
+              OIDC_USER_URL: https://auth.${SECRET_DOMAIN:=internal}/application/o/userinfo/
+              OIDC_END_SESSION_URL: https://auth.${SECRET_DOMAIN:=internal}/application/o/wallos-provider/end-session/
+              OIDC_REDIRECT_URI: https://subs.${SECRET_DOMAIN:=internal}/api/oidc/callback
               OIDC_SCOPES: openid profile email
             envFrom:
               - secretRef:

--- a/kubernetes/components/volsync/externalsecret.yaml
+++ b/kubernetes/components/volsync/externalsecret.yaml
@@ -14,7 +14,7 @@ spec:
       type: Opaque
       data:
         # restic repo per app, under the shared `backups` MinIO bucket
-        RESTIC_REPOSITORY: "s3:https://s3.${SECRET_DOMAIN}/backups/volsync/${APP}"
+        RESTIC_REPOSITORY: "s3:https://s3.${SECRET_DOMAIN:=internal}/backups/volsync/${APP}"
         RESTIC_PASSWORD: "{{ .restic_password }}"
         AWS_ACCESS_KEY_ID: "{{ .aws_access_key_id }}"
         AWS_SECRET_ACCESS_KEY: "{{ .aws_secret_access_key }}"


### PR DESCRIPTION
## Problem

The Kubeconform CI job fails with `✗ variable not set (strict mode): "SECRET_DOMAIN"` (seen on #1105). The recent wallos Authentik OIDC integration added plain `${SECRET_DOMAIN}` references in the OIDC URLs. CI has no decrypted `cluster-secrets`, so `flux envsubst --strict` errors on the unset variable and fails the build at `kubernetes/apps/productivity/wallos/app/`.

## Fix

Add the repo-wide `:=internal` default (the convention used everywhere else) to:

- the 5 wallos OIDC URLs in `kubernetes/apps/productivity/wallos/app/helm-release.yaml`
- the latent plain reference in `kubernetes/components/volsync/externalsecret.yaml` (restic repo URL) — same class of bug, would bite under any strict render

The `${SECRET_DOMAIN/./-}` substitution form (nginx cert names) is unaffected — it doesn't trip strict mode even when unset, so it's left as-is.

## Verification

- Zero plain `${SECRET_DOMAIN}` left in `kubernetes/` (excl. the SOPS file)
- Reproduced CI's failing wallos step (`kustomize | yq | flux envsubst --strict`) → exit 0
- Full `scripts/kubeconform.sh ./kubernetes` → exit 0, 0 strict errors, 336 valid resources

Once merged, #1105 will go green on rebase.