### PR TITLE
fix(system-upgrade): tuppr 0.2.8 and policy.nodrain

### DIFF
--- a/kubernetes/apps/system-upgrade/tuppr/app/helmrelease.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/app/helmrelease.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: tuppr
-      version: 0.2.7
+      version: 0.2.8
       sourceRef:
         kind: HelmRepository
         name: tuppr

--- a/kubernetes/apps/system-upgrade/tuppr/plans/talosupgrade.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/plans/talosupgrade.yaml
@@ -14,6 +14,8 @@ spec:
     rebootMode: default
     placement: hard
     timeout: 30m
+    # Drain nodes before upgrade (the deprecated spec.drain block is replaced by this).
+    nodrain: false
   healthChecks:
     - apiVersion: v1
       kind: Node
@@ -36,5 +38,3 @@ spec:
         operator: In
         values: ["linux"]
   parallelism: 1
-  drain:
-    enabled: true


### PR DESCRIPTION
## Summary

Follow-up to the system-upgrade-controller → tuppr migration. Two small fixes:

- **`TalosUpgrade`: `spec.drain.enabled` → `spec.policy.nodrain: false`.** The current tuppr CRD schema rejects the deprecated `spec.drain` block (`additional properties 'enabled' not allowed`), which was failing kubeconform. `policy.nodrain` is the supported field; `false` is the default and preserves drain-before-upgrade behavior.
- **Bump the tuppr chart `0.2.7` → `0.2.8`.**

## Why

CI (kubeconform) validates the `TalosUpgrade` against tuppr's published CRD schema, where `spec.drain` is deprecated and no longer accepts `enabled`. The `KubernetesUpgrade` was unaffected (no `drain` block).

## Validation

- `git diff` against `main` is limited to the two tuppr files.
- YAML parses; node-draining intent preserved via `policy.nodrain: false`.

## Notes

After merge + Flux reconcile, confirm the new chart is live:

```
flux get hr -n system-upgrade tuppr   # REVISION shows 0.2.8
kubectl -n system-upgrade get pods    # controller rolls onto the new image
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Eru9wGewayckLynF83AvHD)_