### PR TITLE
feat: add paperless-ngx document archive

### DIFF
--- a/docs/authentik-sso-integration.md
+++ b/docs/authentik-sso-integration.md
@@ -89,6 +89,7 @@ Mirror `application_grafana.tf`:
 |-----|--------|-------------------|----------------------|
 | **Grafana** | policy bindings (incl. `admins`, `readers`) | Helm `grafana.ini` `auth.generic_oauth.role_attribute_path` on the `groups` claim | **Yes** — `admins` → Admin, `readers` → Viewer. Both groups now exist and are bound to the app. |
 | **Immich** | policy binding (`users`) | **Internal to Immich** — admin is the first user / set in Immich; Immich does **not** map admin from OIDC group claims | No (cannot, today) |
+| **Paperless** | policy bindings (`users`, `admins`) | **Internal to Paperless** — superuser is the local account bootstrapped from `PAPERLESS_ADMIN_USER`. Paperless can sync *groups* from the `groups` claim (`PAPERLESS_SOCIAL_ACCOUNT_SYNC_GROUPS`) but "superuser" is not a group, so it cannot be granted by claim | No — `admins` gets access only |
 
 > When onboarding a new app, add a row here: how it grants access, how it decides admin, and
 > whether the `admins` group reaches its admin role. If an app can't map admin from a claim
@@ -113,3 +114,4 @@ Mirror `application_grafana.tf`:
 |-----|---------------|-------------|-------|
 | Grafana | ✅ wired (`application_grafana.tf` + Helm `generic_oauth`) | ⏳ `admins` group now bound + role_attribute_path matches `admins` | First target; verify after `site_admin.tf` apply |
 | Immich | ✅ wired (authn) | ❌ admin not via Authentik (internal) | Access via `users` group only |
+| Paperless | ✅ wired (`application_paperless.tf` + django-allauth `openid_connect`) | ❌ superuser not via Authentik (local account) | Provider config is a single JSON blob assembled in the `paperless-oidc` ExternalSecret; callback is `/accounts/oidc/authentik/login/callback/` |

--- a/docs/plans/2026-07-26-paperless-ngx.md
+++ b/docs/plans/2026-07-26-paperless-ngx.md
@@ -1,0 +1,367 @@
+# Paperless-ngx Document Archive
+
+**Date:** 2026-07-26
+**Reference:** <https://docs.paperless-ngx.com/>
+
+---
+
+## Context
+
+The cluster has no document management. Scans, statements, and receipts have nowhere to
+live that is searchable, tagged, and backed up. Paperless-ngx fills that gap: it watches a
+consume directory, OCRs whatever lands there, extracts a date and correspondent, and stores
+the searchable result.
+
+It is a good fit for the existing building blocks — it wants Postgres (CNPG), a Redis-protocol
+broker (the shared dragonfly), a durable document tree (NFS on the NAS), and it speaks OIDC
+(Authentik). Nothing new has to be introduced at the infrastructure layer.
+
+It lands in the `productivity` namespace next to `mealie` and `wallos`.
+
+---
+
+## Current State
+
+- **Namespace**: `productivity` holds `mealie` and `wallos`; its `namespace.yaml` already sets
+  `volsync.backube/privileged-movers: "true"`.
+- **Postgres**: a CNPG operator plus the barman-cloud plugin in `database`. Per
+  `kubernetes/apps/database/README.md`, an app's own Postgres is co-located with the app, not
+  centralized — `immich-database` and `home-assistant-db` both follow that.
+- **Broker**: one shared `Dragonfly` at `dragonfly.database.svc.cluster.local.:6379`, no auth,
+  per-app DB index. Index 0 is authentik/open-webui, index 1 is immich.
+- **Storage**: static `Retain` NFS PVs with a per-app sentinel storage class (`nfs-mealie`,
+  `nfs-immich`, …) for durable data; `openebs-hostpath` for CNPG volumes.
+- **Backups**: `kubernetes/components/volsync` (restic → the shared MinIO `backups` bucket) for
+  PVCs; barman-cloud → the MinIO `databases` bucket for CNPG.
+- **Routing**: nginx `internal` IngressClass, wildcard TLS served by the controller's
+  `default-ssl-certificate`. No Gateway API, no forward-auth — SSO is per-app OIDC.
+- **SSO**: `terraform/authentik/application_<app>.tf` + the `oidc_creds` module, which puts the
+  client credentials in Bitwarden as `authentik-client-<app>`.
+
+Nothing named `paperless` existed anywhere in the repo before this change.
+
+---
+
+## Target State
+
+- `https://paperless.${SECRET_DOMAIN}` serves paperless-ngx v3.
+- Documents live on the NAS at `${SECRET_NFS_PATH}/paperless`, backed up hourly by VolSync.
+- Its Postgres is a dedicated 2-instance CNPG cluster with daily backups to MinIO.
+- Office documents and e-mail are consumable via Gotenberg + Tika sidecars.
+- Login is either the local superuser or Authentik OIDC.
+
+---
+
+## Implementation Steps
+
+### Step 1 — App skeleton
+
+New files:
+
+```
+kubernetes/apps/productivity/paperless/
+├── ks.yaml                     # Flux Kustomization, pulls in the volsync component
+└── app/
+    ├── kustomization.yaml      # namespace + common labels + resource list
+    ├── externalsecret.yaml     # 4 ExternalSecrets (see Step 5)
+    ├── pvc.yaml                # static NFS PV + PVC
+    ├── helmrelease.yaml        # paperless-ngx itself
+    ├── gotenberg.yaml          # Gotenberg sidecar service
+    ├── tika.yaml               # Apache Tika sidecar service
+    └── database/
+        ├── kustomization.yaml
+        ├── cluster.yaml
+        ├── objectstore.yaml
+        └── scheduledbackup.yaml
+```
+
+Modified files:
+
+- `kubernetes/apps/productivity/kustomization.yaml` — add `./paperless/ks.yaml`.
+- `kubernetes/apps/productivity/README.md` — add the app row.
+
+The app is called **`paperless`** everywhere — directory, `APP`, hostname, PVC, restic repo,
+Gatus endpoint — so `${APP}` flows through the volsync and Gatus templates untouched and no
+`GATUS_SUBDOMAIN` or `VOLSYNC_CLAIM` override is needed.
+
+`ks.yaml` depends on external-secrets, the CNPG operator, the barman plugin, the dragonfly
+cluster, and the NFS CSI driver:
+
+```yaml
+  components:
+    - ../../../../components/volsync
+  postBuild:
+    substitute:
+      APP: paperless
+      VOLSYNC_PUID: "1000"
+      VOLSYNC_PGID: "1000"
+  dependsOn:
+    - name: cluster-apps-external-secrets
+    - name: cluster-apps-cloudnative-pg
+    - name: cluster-apps-cnpg-barman-plugin
+    - name: dragonfly-cluster
+    - name: cluster-apps-csi-driver-nfs
+```
+
+### Step 2 — Storage
+
+One static `Retain` PV and one PVC, both named for the app, following `mealie/app/pvc.yaml`
+(which keeps the NAS path behind `${SECRET_NFS_PATH}` rather than hardcoding a share):
+
+```yaml
+  nfs:
+    server: ${SECRET_NFS_SERVER:=192.168.1.1}
+    path: "${SECRET_NFS_PATH:=/data}/paperless"
+```
+
+The image declares four volumes; all four are served from this one claim by `subPath`:
+
+| subPath | mount |
+| --- | --- |
+| `data` | `/usr/src/paperless/data` (search index, classification model) |
+| `media` | `/usr/src/paperless/media` (the documents themselves) |
+| `consume` | `/usr/src/paperless/consume` (drop zone) |
+| `export` | `/usr/src/paperless/export` |
+
+> **Gotcha:** `fsGroup` is not applied to NFS volumes. The four directories must exist on the
+> NAS and be owned by `1000:1000` before the first reconcile, or the pod will crash-loop on
+> permission errors.
+
+VolSync backs the single claim up hourly to `s3://backups/volsync/paperless`.
+
+### Step 3 — Database
+
+A dedicated CNPG `Cluster` in `app/database/`, modelled on `home-assistant/app/database/` —
+the simpler variant with **no** `managed.roles`, so CNPG mints `paperless-database-app`
+carrying `host`/`port`/`dbname`/`username`/`password` and there is no externally-supplied DB
+credential to manage:
+
+```yaml
+  plugins:
+    - name: barman-cloud.cloudnative-pg.io
+      isWALArchiver: true
+      parameters:
+        barmanObjectName: paperless-objectstore
+        serverName: paperless-v1
+  bootstrap:
+    initdb:
+      database: paperless
+      owner: paperless
+```
+
+`ObjectStore` writes to `s3://databases/` with a 30d retention; `ScheduledBackup` runs
+`@daily`. No new MinIO bucket — the shared `databases` bucket and its `minio-tf-databases`
+credential already exist.
+
+### Step 4 — Application
+
+app-template `3.7.3`, one controller, one container. The upstream image runs the webserver,
+celery worker and scheduler under s6, so no separate worker Deployment is needed.
+
+```yaml
+  strategy: Recreate      # single writer against NFS and the Tantivy index
+  image:
+    repository: ghcr.io/paperless-ngx/paperless-ngx
+    tag: v3.0.3
+```
+
+The settings worth calling out:
+
+```yaml
+  PAPERLESS_REDIS: redis://dragonfly.database.svc.cluster.local.:6379/2
+  PAPERLESS_CONSUMER_POLLING_INTERVAL: "60"
+  PAPERLESS_TIKA_ENABLED: "1"
+  PAPERLESS_TIKA_ENDPOINT: http://paperless-tika.productivity.svc.cluster.local:9998
+  PAPERLESS_TIKA_GOTENBERG_ENDPOINT: http://paperless-gotenberg.productivity.svc.cluster.local:3000
+  PAPERLESS_APPS: allauth.socialaccount.providers.openid_connect
+```
+
+> **Gotcha:** v3.0 removed `PAPERLESS_CONSUMER_POLLING` and replaced the inotify-based consumer
+> with `watchfiles`. The replacement knob is **`PAPERLESS_CONSUMER_POLLING_INTERVAL`** (seconds,
+> `0` = native notifications). It must be non-zero here: inotify does not work over NFS, so with
+> the default the consume directory is silently never scanned.
+
+DB connection values come from the CNPG-generated secret:
+
+```yaml
+  PAPERLESS_DBHOST:
+    valueFrom:
+      secretKeyRef:
+        name: paperless-database-app
+        key: host
+```
+
+The v3 image supports true rootless operation — the process starts directly as the supplied
+uid/gid with no internal remapping — so the pod runs `runAsNonRoot` as `1000:1000` and the
+legacy `USERMAP_UID`/`USERMAP_GID` remapping variables are **not** set. (The one restriction is
+that rootless is incompatible with extra OCR language packs via `PAPERLESS_OCR_LANGUAGES`;
+`PAPERLESS_OCR_LANGUAGE: eng` is built in and unaffected.)
+
+Ingress is `className: internal` on `paperless.${SECRET_DOMAIN}` with
+`proxy-body-size: "0"` and `proxy-request-buffering: "off"`, the same treatment immich gets for
+large uploads.
+
+Gotenberg and Tika are two more small app-template HelmReleases in the same namespace. Because
+each declares a single service, the bjw-s chart names the Service after the release, so they
+resolve as `paperless-gotenberg` and `paperless-tika`. Gotenberg is configured exactly as
+upstream's compose file recommends, passing the flags as **`args`** so the image's `tini`
+entrypoint is preserved:
+
+```yaml
+  args:
+    - gotenberg
+    - --chromium-disable-javascript=true
+    - --chromium-allow-list=file:///tmp/.*
+```
+
+### Step 5 — Secrets
+
+Four `ExternalSecret`s. Two Bitwarden stores are involved because `bitwarden-login` reads an
+item's username/password while `bitwarden-fields` reads its custom fields.
+
+| ExternalSecret | Store | Bitwarden item | Produces |
+| --- | --- | --- | --- |
+| `minio-paperless-pgsql` | `bitwarden-login` | `minio-tf-databases` | S3 creds for the barman ObjectStore |
+| `paperless-admin` | `bitwarden-login` | `paperless credentials` | `PAPERLESS_ADMIN_USER`, `PAPERLESS_ADMIN_PASSWORD` |
+| `paperless-fields` | `bitwarden-fields` | `paperless credentials` → `secret_key` | `PAPERLESS_SECRET_KEY` |
+| `paperless-oidc` | `bitwarden-login` | `authentik-client-paperless` | `PAPERLESS_SOCIALACCOUNT_PROVIDERS` |
+
+django-allauth takes its whole provider configuration as one JSON blob, so that JSON is
+assembled inside the ExternalSecret template — the client secret never appears in Git:
+
+```yaml
+  target:
+    template:
+      engineVersion: v2
+      data:
+        PAPERLESS_SOCIALACCOUNT_PROVIDERS: >-
+          {"openid_connect": {"APPS": [{"provider_id": "authentik",
+          "name": "Authentik",
+          "client_id": "{{ .client_id }}",
+          "secret": "{{ .client_secret }}",
+          "settings": {"server_url":
+          "https://auth.${SECRET_DOMAIN:=internal}/application/o/paperless-provider/.well-known/openid-configuration"}}]}}
+```
+
+### Step 6 — OpenTofu
+
+New file `terraform/authentik/application_paperless.tf`, mirroring `application_wallos.tf`:
+the `oidc_creds` module (which creates the Bitwarden item `authentik-client-paperless`), an
+`authentik_provider_oauth2` named `paperless-provider`, the `authentik_application`, and a
+`users` policy binding. The callback registered in `allowed_redirect_uris` is
+`https://paperless.${var.domain}/accounts/oidc/authentik/login/callback/` — the `authentik`
+path segment is the `provider_id` from the JSON above and the two must stay in sync.
+
+Because `slug = authentik_provider_oauth2.paperless_oauth.name`, the issuer path is
+`/application/o/paperless-provider/`.
+
+`site_admin.tf` gains an `admins_paperless` binding (access only — see below).
+
+`terraform/bitwarden/main.tf` gains a `paperless credentials` item: username `admin`, a random
+password, and a hidden `secret_key` field. No Postgres credential is stored there — CNPG mints
+its own.
+
+---
+
+## Files Summary
+
+| Action | Path |
+| --- | --- |
+| CREATE | `kubernetes/apps/productivity/paperless/ks.yaml` |
+| CREATE | `kubernetes/apps/productivity/paperless/app/kustomization.yaml` |
+| CREATE | `kubernetes/apps/productivity/paperless/app/externalsecret.yaml` |
+| CREATE | `kubernetes/apps/productivity/paperless/app/pvc.yaml` |
+| CREATE | `kubernetes/apps/productivity/paperless/app/helmrelease.yaml` |
+| CREATE | `kubernetes/apps/productivity/paperless/app/gotenberg.yaml` |
+| CREATE | `kubernetes/apps/productivity/paperless/app/tika.yaml` |
+| CREATE | `kubernetes/apps/productivity/paperless/app/database/kustomization.yaml` |
+| CREATE | `kubernetes/apps/productivity/paperless/app/database/cluster.yaml` |
+| CREATE | `kubernetes/apps/productivity/paperless/app/database/objectstore.yaml` |
+| CREATE | `kubernetes/apps/productivity/paperless/app/database/scheduledbackup.yaml` |
+| CREATE | `terraform/authentik/application_paperless.tf` |
+| CREATE | `docs/plans/2026-07-26-paperless-ngx.md` |
+| MODIFY | `kubernetes/apps/productivity/kustomization.yaml` |
+| MODIFY | `kubernetes/apps/productivity/README.md` |
+| MODIFY | `terraform/authentik/site_admin.tf` |
+| MODIFY | `terraform/bitwarden/main.tf` |
+| MODIFY | `docs/authentik-sso-integration.md` |
+
+---
+
+## Key Design Decisions
+
+- **Dedicated CNPG cluster, not the shared `postgres`.** `kubernetes/apps/database/README.md`
+  prescribes co-locating an app's database with the app to keep the blast radius local. Both
+  immich and home-assistant already do this.
+- **No `managed.roles`.** Letting CNPG generate `paperless-database-app` removes an entire
+  Bitwarden item and ExternalSecret from the design, and the app reads host/port/dbname from
+  the same secret it reads the password from.
+- **One PVC with `subPath` mounts, not four PVCs.** The four directories are one logical
+  archive, they back up as one restic repo, and the volsync component takes a single
+  `VOLSYNC_CLAIM`. Splitting them would mean four ReplicationSources for no benefit.
+- **`data/` on NFS rather than `openebs-hostpath`.** The search index could be rebuilt after a
+  restore, but keeping it on the backed-up claim means a restore is complete without an
+  out-of-band reindex. The cost is Tantivy over NFS, which is acceptable for a single writer.
+- **Rootless rather than `USERMAP_*`.** v3 images start directly as the supplied uid/gid, so the
+  repo's usual `runAsNonRoot` posture works without the image's privilege-dropping shim.
+- **`strategy: Recreate`.** Two replicas would have two writers on the same NFS tree and the
+  same Tantivy index; a rolling update would briefly do the same.
+- **Local superuser kept alongside SSO.** Paperless cannot derive "superuser" from an OIDC
+  claim, so the Bitwarden-backed local admin remains the only way to administer it — and the
+  only way in if Authentik is down. `PAPERLESS_ACCOUNT_ALLOW_SIGNUPS` stays `false` so the
+  regular login form cannot be used to self-register.
+- **Shared dragonfly, index 2.** Consistent with immich (1) and authentik/open-webui (0); no
+  per-app broker to run or back up.
+
+---
+
+## Verification
+
+No cluster access from the authoring environment — these are the owner's steps after merge.
+
+```bash
+# 0. static checks, the way CI does them
+task k8s:kubeconform
+bash scripts/validate-ks-paths.sh kubernetes
+yamllint .
+(cd terraform/authentik && tofu fmt -check && tofu validate)
+
+# 1. out-of-band prerequisites (nothing works before these)
+(cd terraform/bitwarden && tofu apply)   # creates "paperless credentials"
+(cd terraform/authentik && tofu apply)   # creates "authentik-client-paperless"
+#    on the NAS: mkdir -p <nfs-path>/paperless/{data,media,consume,export}
+#                chown -R 1000:1000 <nfs-path>/paperless
+
+# 2. reconcile
+flux reconcile ks cluster-apps --with-source
+flux get ks cluster-apps-paperless                   # expect: Ready
+
+# 3. secrets and database
+kubectl -n productivity get externalsecret           # expect: 4x SecretSynced
+kubectl -n productivity get cluster paperless-database   # expect: 2 instances healthy
+kubectl -n productivity get backup                   # expect: first backup Completed
+
+# 4. app
+kubectl -n productivity get pods -l app.kubernetes.io/name=paperless
+#    browse https://paperless.${SECRET_DOMAIN}
+#      - local admin login works
+#      - "Authentik" button completes the OIDC round-trip
+
+# 5. consumption
+#    drop a PDF into <nfs-path>/paperless/consume -> appears in the UI within ~60s
+#    drop a .docx  -> also consumed (proves Tika + Gotenberg)
+
+# 6. backups
+kubectl -n productivity get replicationsource paperless   # expect: lastSyncTime set within the hour
+#    Gatus shows `paperless` green in both `internal` and `internal-guarded`
+```
+
+---
+
+## Rollback
+
+Remove `./paperless/ks.yaml` from `kubernetes/apps/productivity/kustomization.yaml` and
+reconcile; Flux prunes the namespace's paperless resources. The NFS PV is
+`persistentVolumeReclaimPolicy: Retain`, the CNPG PVCs are not deleted with the Cluster, and
+both the restic and barman repositories stay in MinIO — so the documents and the database
+survive a teardown and a later re-apply re-binds to them.

--- a/kubernetes/apps/productivity/README.md
+++ b/kubernetes/apps/productivity/README.md
@@ -2,9 +2,10 @@
 
 Personal productivity and self-hosted utilities.
 
-Both apps are backed up to MinIO via [VolSync](../volsync-system/README.md).
+Every app here is backed up to MinIO via [VolSync](../volsync-system/README.md).
 
 | App | Description | Manifest |
 | --- | --- | --- |
 | [mealie](https://mealie.io/) | Recipe manager and meal planner (data on a static `Retain` NFS PV). | [ks.yaml](./mealie/ks.yaml) |
+| [paperless](https://docs.paperless-ngx.com/) | Document archive: OCRs incoming scans and indexes them. Own CNPG Postgres, shared dragonfly broker, Gotenberg + Tika sidecars for Office/e-mail parsing, documents on a static `Retain` NFS PV. | [ks.yaml](./paperless/ks.yaml) |
 | [wallos](https://github.com/ellite/Wallos) | Subscription and recurring-payment tracker. | [ks.yaml](./wallos/ks.yaml) |

--- a/kubernetes/apps/productivity/kustomization.yaml
+++ b/kubernetes/apps/productivity/kustomization.yaml
@@ -4,4 +4,5 @@ kind: Kustomization
 resources:
   - ./namespace.yaml
   - ./mealie/ks.yaml
+  - ./paperless/ks.yaml
   - ./wallos/ks.yaml

--- a/kubernetes/apps/productivity/paperless/app/database/cluster.yaml
+++ b/kubernetes/apps/productivity/paperless/app/database/cluster.yaml
@@ -1,0 +1,48 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/postgresql.cnpg.io/cluster_v1.json
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: paperless-database
+  namespace: productivity
+spec:
+  instances: 2
+  # Stock CNPG image — paperless-ngx needs no Postgres extensions beyond the
+  # defaults, so there is nothing to load in postInitApplicationSQL.
+  imageName: ghcr.io/cloudnative-pg/postgresql:16.0-10
+  primaryUpdateStrategy: unsupervised
+  storage:
+    size: 10Gi
+    storageClass: openebs-hostpath
+  enableSuperuserAccess: true
+  nodeMaintenanceWindow:
+    inProgress: false
+    reusePVC: true
+  resources:
+    requests:
+      cpu: 100m
+    limits:
+      memory: 1Gi
+  monitoring:
+    enablePodMonitor: true
+    # Ref: https://github.com/cloudnative-pg/cloudnative-pg/issues/2501
+    podMonitorMetricRelabelings:
+      - {
+          sourceLabels: ["cluster"],
+          targetLabel: cnpg_cluster,
+          action: replace,
+        }
+      - { regex: cluster, action: labeldrop }
+  plugins:
+    - name: barman-cloud.cloudnative-pg.io
+      isWALArchiver: true
+      parameters:
+        barmanObjectName: paperless-objectstore
+        serverName: paperless-v1
+  # No managed.roles block: CNPG then auto-generates the paperless-database-app
+  # secret (username/password/host/port/dbname/uri) for the bootstrap owner,
+  # so no externally-supplied DB credential is needed.
+  bootstrap:
+    initdb:
+      database: paperless
+      owner: paperless

--- a/kubernetes/apps/productivity/paperless/app/database/kustomization.yaml
+++ b/kubernetes/apps/productivity/paperless/app/database/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./objectstore.yaml
+  - ./cluster.yaml
+  - ./scheduledbackup.yaml

--- a/kubernetes/apps/productivity/paperless/app/database/objectstore.yaml
+++ b/kubernetes/apps/productivity/paperless/app/database/objectstore.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: barmancloud.cnpg.io/v1
+kind: ObjectStore
+metadata:
+  name: paperless-objectstore
+  namespace: productivity
+spec:
+  # Retention lives on the ObjectStore in the plugin model (was Cluster.spec.backup.retentionPolicy)
+  retentionPolicy: 30d
+  configuration:
+    destinationPath: s3://databases/
+    endpointURL: https://s3.${SECRET_DOMAIN:=internal}
+    # serverName is set via the Cluster's plugin parameters (forbidden here)
+    s3Credentials:
+      accessKeyId:
+        name: minio-paperless-pgsql
+        key: minio_s3_access_key
+      secretAccessKey:
+        name: minio-paperless-pgsql
+        key: minio_s3_secret_access_key
+    wal:
+      compression: bzip2
+      maxParallel: 2
+    data:
+      compression: bzip2

--- a/kubernetes/apps/productivity/paperless/app/database/scheduledbackup.yaml
+++ b/kubernetes/apps/productivity/paperless/app/database/scheduledbackup.yaml
@@ -1,0 +1,16 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/postgresql.cnpg.io/scheduledbackup_v1.json
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: paperless-database
+  namespace: productivity
+spec:
+  schedule: "@daily"
+  immediate: true
+  backupOwnerReference: self
+  method: plugin
+  pluginConfiguration:
+    name: barman-cloud.cloudnative-pg.io
+  cluster:
+    name: paperless-database

--- a/kubernetes/apps/productivity/paperless/app/externalsecret.yaml
+++ b/kubernetes/apps/productivity/paperless/app/externalsecret.yaml
@@ -1,0 +1,128 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+# MinIO S3 credentials for the shared `databases` bucket, consumed by the CNPG
+# barman-cloud ObjectStore (terraform/minio -> minio-tf-databases).
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: minio-paperless-pgsql
+  namespace: productivity
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: bitwarden-login
+  target:
+    deletionPolicy: Delete
+    template:
+      type: Opaque
+      metadata:
+        labels:
+          cnpg.io/reload: "true"
+      data:
+        minio_s3_access_key: |-
+          {{ .minio_user }}
+        minio_s3_secret_access_key: |-
+          {{ .minio_secret }}
+  refreshInterval: 15m
+  data:
+    - secretKey: minio_user
+      remoteRef:
+        key: minio-tf-databases
+        property: username
+    - secretKey: minio_secret
+      remoteRef:
+        key: minio-tf-databases
+        property: password
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+# Local superuser bootstrapped on first start — the fallback login if Authentik
+# is unavailable (terraform/bitwarden -> "paperless credentials").
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: paperless-admin
+  namespace: productivity
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: bitwarden-login
+  target:
+    name: paperless-admin-secret
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        PAPERLESS_ADMIN_USER: "{{ .admin_user }}"
+        PAPERLESS_ADMIN_PASSWORD: "{{ .admin_password }}"
+  refreshInterval: 1h
+  data:
+    - secretKey: admin_user
+      remoteRef:
+        key: paperless credentials
+        property: username
+    - secretKey: admin_password
+      remoteRef:
+        key: paperless credentials
+        property: password
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+# Django SECRET_KEY. Lives as a custom field on the same Bitwarden item, so it
+# needs the `bitwarden-fields` store rather than `bitwarden-login`.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: paperless-fields
+  namespace: productivity
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: bitwarden-fields
+  target:
+    name: paperless-fields-secret
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        PAPERLESS_SECRET_KEY: "{{ .secret_key }}"
+  refreshInterval: 1h
+  data:
+    - secretKey: secret_key
+      remoteRef:
+        key: paperless credentials
+        property: secret_key
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+# Authentik OIDC client. django-allauth takes its whole provider config as one
+# JSON blob, so it is assembled here — the client secret never lands in Git.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: paperless-oidc
+  namespace: productivity
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: bitwarden-login
+  target:
+    name: paperless-oidc-secret
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        PAPERLESS_SOCIALACCOUNT_PROVIDERS: >-
+          {"openid_connect": {"APPS": [{"provider_id": "authentik",
+          "name": "Authentik",
+          "client_id": "{{ .client_id }}",
+          "secret": "{{ .client_secret }}",
+          "settings": {"server_url":
+          "https://auth.${SECRET_DOMAIN:=internal}/application/o/paperless-provider/.well-known/openid-configuration"}}]}}
+  refreshInterval: 1h
+  data:
+    - secretKey: client_id
+      remoteRef:
+        key: authentik-client-paperless
+        property: username
+    - secretKey: client_secret
+      remoteRef:
+        key: authentik-client-paperless
+        property: password

--- a/kubernetes/apps/productivity/paperless/app/gotenberg.yaml
+++ b/kubernetes/apps/productivity/paperless/app/gotenberg.yaml
@@ -1,0 +1,82 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2beta2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: paperless-gotenberg
+  namespace: productivity
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: app-template
+      version: 3.7.3
+      sourceRef:
+        kind: HelmRepository
+        name: bjw-s
+        namespace: flux-system
+      interval: 30m
+  maxHistory: 2
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  uninstall:
+    keepHistory: false
+  values:
+    controllers:
+      gotenberg:
+        containers:
+          app:
+            image:
+              repository: docker.io/gotenberg/gotenberg
+              tag: "8.34"
+            # args only (not command) so the image's tini entrypoint is kept
+            args:
+              - gotenberg
+              # paperless uses the chromium route to render .eml files — deny
+              # external content such as tracking pixels and javascript
+              - --chromium-disable-javascript=true
+              - --chromium-allow-list=file:///tmp/.*
+            probes:
+              liveness: &probe
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: 3000
+                  periodSeconds: 30
+                  failureThreshold: 5
+              readiness: *probe
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 25m
+                memory: 128Mi
+              limits:
+                memory: 1Gi
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: &runAsUser 1001
+        runAsGroup: &runAsGroup 1001
+        fsGroup: *runAsGroup
+        seccompProfile: { type: RuntimeDefault }
+    service:
+      app:
+        controller: gotenberg
+        ports:
+          http:
+            port: 3000
+    persistence:
+      tmp:
+        enabled: true
+        type: emptyDir
+        globalMounts:
+          - path: /tmp

--- a/kubernetes/apps/productivity/paperless/app/helmrelease.yaml
+++ b/kubernetes/apps/productivity/paperless/app/helmrelease.yaml
@@ -1,0 +1,185 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2beta2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: paperless
+  namespace: productivity
+spec:
+  interval: 30m
+  timeout: 15m
+  chart:
+    spec:
+      chart: app-template
+      version: 3.7.3
+      sourceRef:
+        kind: HelmRepository
+        name: bjw-s
+        namespace: flux-system
+      interval: 30m
+  maxHistory: 2
+  install:
+    createNamespace: true
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  uninstall:
+    keepHistory: false
+  values:
+    controllers:
+      paperless:
+        # single writer against the NFS document tree and the Tantivy index
+        strategy: Recreate
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: ghcr.io/paperless-ngx/paperless-ngx
+              tag: v3.0.3
+            env:
+              PAPERLESS_URL: https://paperless.${SECRET_DOMAIN:=internal}
+              PAPERLESS_TIME_ZONE: "${TIMEZONE:=America/New_York}"
+              PAPERLESS_OCR_LANGUAGE: eng
+              # shared dragonfly; index 0 is authentik/open-webui, 1 is immich
+              PAPERLESS_REDIS: redis://dragonfly.database.svc.cluster.local.:6379/2
+              PAPERLESS_DBENGINE: postgresql
+              PAPERLESS_DBHOST:
+                valueFrom:
+                  secretKeyRef:
+                    name: &dbSecret paperless-database-app
+                    key: host
+              PAPERLESS_DBPORT:
+                valueFrom:
+                  secretKeyRef:
+                    name: *dbSecret
+                    key: port
+              PAPERLESS_DBNAME:
+                valueFrom:
+                  secretKeyRef:
+                    name: *dbSecret
+                    key: dbname
+              PAPERLESS_DBUSER:
+                valueFrom:
+                  secretKeyRef:
+                    name: *dbSecret
+                    key: username
+              PAPERLESS_DBPASS:
+                valueFrom:
+                  secretKeyRef:
+                    name: *dbSecret
+                    key: password
+              # inotify does not work over NFS — poll the consume directory
+              PAPERLESS_CONSUMER_POLLING_INTERVAL: "60"
+              PAPERLESS_CONSUMER_RECURSIVE: "true"
+              PAPERLESS_CONSUMER_SUBDIRS_AS_TAGS: "true"
+              # Office documents and e-mail are parsed by the sidecar services
+              PAPERLESS_TIKA_ENABLED: "1"
+              PAPERLESS_TIKA_ENDPOINT: http://paperless-tika.productivity.svc.cluster.local:9998
+              PAPERLESS_TIKA_GOTENBERG_ENDPOINT: http://paperless-gotenberg.productivity.svc.cluster.local:3000
+              # Authentik SSO via django-allauth; the provider JSON (which carries
+              # the client secret) is assembled in paperless-oidc-secret
+              PAPERLESS_APPS: allauth.socialaccount.providers.openid_connect
+              PAPERLESS_ACCOUNT_DEFAULT_HTTP_PROTOCOL: https
+              PAPERLESS_SOCIAL_AUTO_SIGNUP: "true"
+              PAPERLESS_ACCOUNT_ALLOW_SIGNUPS: "false"
+            envFrom:
+              - secretRef:
+                  name: paperless-admin-secret
+              - secretRef:
+                  name: paperless-fields-secret
+              - secretRef:
+                  name: paperless-oidc-secret
+            probes:
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet: &probe
+                    path: /accounts/login/
+                    port: 8000
+                  # first boot runs migrations and builds the search index
+                  initialDelaySeconds: 30
+                  periodSeconds: 10
+                  failureThreshold: 60
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet: *probe
+                  periodSeconds: 30
+                  failureThreshold: 5
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet: *probe
+                  periodSeconds: 30
+                  failureThreshold: 5
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 100m
+                memory: 512Mi
+              limits:
+                memory: 4Gi
+    defaultPodOptions:
+      # v3 images run rootless: the process starts directly as this uid/gid with
+      # no internal remapping, so the NFS tree must be owned by 1000:1000.
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: &runAsUser 1000
+        runAsGroup: &runAsGroup 1000
+        fsGroup: *runAsGroup
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile: { type: RuntimeDefault }
+    service:
+      app:
+        controller: paperless
+        ports:
+          http:
+            port: 8000
+    ingress:
+      app:
+        enabled: true
+        className: internal
+        annotations:
+          # scans can be large; stream them straight through to the app
+          nginx.ingress.kubernetes.io/proxy-body-size: "0"
+          nginx.ingress.kubernetes.io/proxy-request-buffering: "off"
+        hosts:
+          - host: &host paperless.${SECRET_DOMAIN:=internal}
+            paths:
+              - path: /
+                pathType: Prefix
+                service:
+                  identifier: app
+                  port: http
+        tls:
+          - hosts:
+              - *host
+            secretName: wildcard-cert-tls
+    persistence:
+      # one NFS claim, split by subPath into the four volumes the image declares
+      data:
+        enabled: true
+        existingClaim: paperless
+        globalMounts:
+          - path: /usr/src/paperless/data
+            subPath: data
+          - path: /usr/src/paperless/media
+            subPath: media
+          - path: /usr/src/paperless/consume
+            subPath: consume
+          - path: /usr/src/paperless/export
+            subPath: export
+      tmp:
+        enabled: true
+        type: emptyDir
+        globalMounts:
+          - path: /tmp

--- a/kubernetes/apps/productivity/paperless/app/kustomization.yaml
+++ b/kubernetes/apps/productivity/paperless/app/kustomization.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: productivity
+labels:
+  - pairs:
+      app.kubernetes.io/name: paperless
+      app.kubernetes.io/instance: paperless
+      app.kubernetes.io/part-of: paperless
+resources:
+  - ./externalsecret.yaml
+  - ./pvc.yaml
+  - ./database
+  - ./helmrelease.yaml
+  - ./gotenberg.yaml
+  - ./tika.yaml
+  - ../../../../templates/gatus/guarded

--- a/kubernetes/apps/productivity/paperless/app/pvc.yaml
+++ b/kubernetes/apps/productivity/paperless/app/pvc.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: nfs-paperless
+  namespace: productivity
+  labels:
+    app.kubernetes.io/name: &name paperless
+    app.kubernetes.io/instance: *name
+spec:
+  storageClassName: nfs-paperless
+  capacity:
+    storage: 500Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  nfs:
+    server: ${SECRET_NFS_SERVER:=192.168.1.1}
+    path: "${SECRET_NFS_PATH:=/data}/paperless"
+  mountOptions:
+    - nfsvers=4.1
+    - tcp
+    - hard
+    - noatime
+    - nodiratime
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.26.1-standalone-strict/persistentvolumeclaim-v1.json
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: paperless
+  namespace: productivity
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 50Gi
+  storageClassName: nfs-paperless

--- a/kubernetes/apps/productivity/paperless/app/tika.yaml
+++ b/kubernetes/apps/productivity/paperless/app/tika.yaml
@@ -1,0 +1,76 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2beta2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: paperless-tika
+  namespace: productivity
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: app-template
+      version: 3.7.3
+      sourceRef:
+        kind: HelmRepository
+        name: bjw-s
+        namespace: flux-system
+      interval: 30m
+  maxHistory: 2
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  uninstall:
+    keepHistory: false
+  values:
+    controllers:
+      tika:
+        containers:
+          app:
+            image:
+              # the -full variant carries the OCR/office parsers paperless needs
+              repository: docker.io/apache/tika
+              tag: 3.3.1.0-full
+            probes:
+              liveness: &probe
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /tika
+                    port: 9998
+                  periodSeconds: 30
+                  failureThreshold: 5
+              readiness: *probe
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 25m
+                memory: 256Mi
+              limits:
+                memory: 1Gi
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: &runAsUser 35002
+        runAsGroup: &runAsGroup 35002
+        fsGroup: *runAsGroup
+        seccompProfile: { type: RuntimeDefault }
+    service:
+      app:
+        controller: tika
+        ports:
+          http:
+            port: 9998
+    persistence:
+      tmp:
+        enabled: true
+        type: emptyDir
+        globalMounts:
+          - path: /tmp

--- a/kubernetes/apps/productivity/paperless/ks.yaml
+++ b/kubernetes/apps/productivity/paperless/ks.yaml
@@ -1,0 +1,36 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cluster-apps-paperless
+  namespace: flux-system
+spec:
+  targetNamespace: productivity
+  interval: 10m
+  path: "./kubernetes/apps/productivity/paperless/app"
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-kubernetes
+  wait: true
+  components:
+    - ../../../../components/volsync
+  postBuild:
+    substitute:
+      APP: paperless
+      # the image starts as root and drops to the `paperless` user (USERMAP_*),
+      # so the restic mover reads the NFS tree as that same uid/gid
+      VOLSYNC_PUID: "1000"
+      VOLSYNC_PGID: "1000"
+    substituteFrom:
+      - kind: ConfigMap
+        name: cluster-settings
+      - kind: Secret
+        name: cluster-secrets
+  dependsOn:
+    - name: cluster-apps-external-secrets
+    - name: cluster-apps-cloudnative-pg
+    - name: cluster-apps-cnpg-barman-plugin
+    - name: dragonfly-cluster
+    - name: cluster-apps-csi-driver-nfs

--- a/terraform/authentik/application_paperless.tf
+++ b/terraform/authentik/application_paperless.tf
@@ -1,0 +1,61 @@
+## -----------------------------------------------------------------------------
+## Authentik Application - Paperless-ngx
+## These are resources for paperless-ngx to use authentik for SSO
+## -----------------------------------------------------------------------------
+
+## -------------------------------------------
+## Paperless - Authentication (authn) resources
+## -------------------------------------------
+module "paperless_oidc_creds" {
+  source          = "./oidc_creds"
+  application     = "paperless"
+  organization_id = var.organization_id
+  collection_id   = var.collection_id
+}
+
+resource "authentik_provider_oauth2" "paperless_oauth" {
+  name = "paperless-provider"
+
+  client_id     = module.paperless_oidc_creds.client_id
+  client_secret = module.paperless_oidc_creds.client_secret
+
+  authorization_flow = resource.authentik_flow.provider-authorization-implicit-consent.uuid
+  invalidation_flow  = resource.authentik_flow.invalidation.uuid
+
+  property_mappings = data.authentik_property_mapping_provider_scope.oauth2.ids
+
+  access_token_validity = "hours=8"
+
+  # django-allauth's openid_connect provider callback. The "authentik" path
+  # segment is the provider_id in PAPERLESS_SOCIALACCOUNT_PROVIDERS.
+  allowed_redirect_uris = [
+    {
+      matching_mode     = "strict",
+      redirect_uri_type = "authorization",
+      url               = "https://paperless.${var.domain}/accounts/oidc/authentik/login/callback/"
+    }
+  ]
+}
+
+resource "authentik_application" "paperless_application" {
+  name               = "Paperless"
+  slug               = authentik_provider_oauth2.paperless_oauth.name
+  protocol_provider  = authentik_provider_oauth2.paperless_oauth.id
+  group              = authentik_group.home.name
+  open_in_new_tab    = true
+  meta_icon          = "https://raw.githubusercontent.com/walkxcode/dashboard-icons/main/png/paperless.png"
+  meta_launch_url    = "https://paperless.${var.domain}"
+  policy_engine_mode = "any"
+}
+
+## ------------------------------------------
+## Paperless - Authorization (authz) resources
+## ------------------------------------------
+# All users can access Paperless. Paperless has no group-driven admin role, so
+# the superuser stays the local account bootstrapped from PAPERLESS_ADMIN_USER
+# (terraform/bitwarden -> "paperless credentials").
+resource "authentik_policy_binding" "paperless_users" {
+  target = authentik_application.paperless_application.uuid
+  group  = authentik_group.users.id
+  order  = 0
+}

--- a/terraform/authentik/site_admin.tf
+++ b/terraform/authentik/site_admin.tf
@@ -67,3 +67,11 @@ resource "authentik_policy_binding" "admins_grafana" {
   group  = authentik_group.admins.id
   order  = 30
 }
+
+## Access only — paperless-ngx has no group-driven admin role, so its superuser is the
+## local account bootstrapped from PAPERLESS_ADMIN_USER, not this group.
+resource "authentik_policy_binding" "admins_paperless" {
+  target = authentik_application.paperless_application.uuid
+  group  = authentik_group.admins.id
+  order  = 30
+}

--- a/terraform/bitwarden/main.tf
+++ b/terraform/bitwarden/main.tf
@@ -279,6 +279,47 @@ resource "bitwarden_item_login" "immich" {
 }
 
 ################################################################################
+# paperless-ngx credentials
+################################################################################
+# Bootstraps the local paperless superuser (the fallback login when Authentik is
+# unavailable) and Django's SECRET_KEY. Postgres credentials are NOT here — the
+# CNPG cluster mints its own `paperless-database-app` secret in the cluster.
+resource "random_password" "paperless_admin_password" {
+  length           = 32
+  special          = true
+  override_special = "_=+-,~"
+}
+
+resource "random_password" "paperless_secret_key" {
+  length  = 64
+  special = false
+}
+
+resource "bitwarden_item_login" "paperless" {
+  organization_id = var.terraform_organization
+  collection_ids  = [var.collection_id]
+
+  name     = "paperless credentials"
+  username = "admin"
+  password = random_password.paperless_admin_password.result
+
+  uri {
+    value = "https://paperless.${local.domain}"
+    match = "host"
+  }
+
+  field {
+    name    = "terraform managed"
+    boolean = true
+  }
+
+  field {
+    name   = "secret_key"
+    hidden = random_password.paperless_secret_key.result
+  }
+}
+
+################################################################################
 # volsync restic repository password
 ################################################################################
 # Encryption password for the VolSync/restic backup repositories in MinIO. The


### PR DESCRIPTION
## Summary

- Add paperless-ngx to the `productivity` namespace: webserver + Gotenberg + Tika sidecars (app-template 3.7.3), so Office documents and e-mail are consumable alongside PDFs/images.
- Dedicated CNPG Postgres cluster co-located with the app, with daily barman-cloud backups to the shared `databases` MinIO bucket.
- Documents live on a static `Retain` NFS PV, backed up hourly to MinIO via the shared VolSync component.
- Wire up Authentik OIDC SSO (`terraform/authentik/application_paperless.tf`) with a local-admin fallback, both sourced from Bitwarden via OpenTofu (`terraform/bitwarden/main.tf`).
- Add a design doc at `docs/plans/2026-07-26-paperless-ngx.md` and update `docs/authentik-sso-integration.md`.

## Test plan

- [x] `kustomize build | flux envsubst --strict | kubeconform` on the new app and every other app kustomization in the repo (no regressions)
- [x] `scripts/validate-ks-paths.sh` — all Flux Kustomization paths resolve
- [x] `yamllint` — no new findings beyond the pre-existing repo-wide style exceptions (long lines, brace spacing) also present in the files this was modeled on
- [x] `tofu fmt -check` on `terraform/authentik` and `terraform/bitwarden`
- [ ] `tofu apply` in `terraform/bitwarden` then `terraform/authentik` (owner will run after merge — creates the Bitwarden items the ExternalSecrets depend on)
- [ ] Flux reconcile + on-cluster verification (see the Verification section of the design doc)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SzhAtMmyvLkAMXT6LrNs67)_