### PR TITLE
fix(paperless): correct paperless-ngx image tag

### DIFF
--- a/docs/plans/2026-07-26-paperless-ngx.md
+++ b/docs/plans/2026-07-26-paperless-ngx.md
@@ -162,7 +162,7 @@ celery worker and scheduler under s6, so no separate worker Deployment is needed
   strategy: Recreate      # single writer against NFS and the Tantivy index
   image:
     repository: ghcr.io/paperless-ngx/paperless-ngx
-    tag: v3.0.3
+    tag: 3.0.3   # ghcr tags drop the GitHub release's "v" prefix
 ```
 
 The settings worth calling out:

--- a/kubernetes/apps/productivity/paperless/app/helmrelease.yaml
+++ b/kubernetes/apps/productivity/paperless/app/helmrelease.yaml
@@ -39,7 +39,8 @@ spec:
           app:
             image:
               repository: ghcr.io/paperless-ngx/paperless-ngx
-              tag: v3.0.3
+              # NOTE: ghcr image tags have no "v" prefix, unlike the GitHub release tag
+              tag: 3.0.3
             env:
               PAPERLESS_URL: https://paperless.${SECRET_DOMAIN:=internal}
               PAPERLESS_TIME_ZONE: "${TIMEZONE:=America/New_York}"


### PR DESCRIPTION
## Summary

- `ghcr.io/paperless-ngx/paperless-ngx` tags drop the `v` prefix used by the GitHub release tag — `v3.0.3` doesn't exist on the registry, only `3.0.3` does. This was causing `ImagePullBackOff` on the paperless deployment from #1149.
- Confirmed via the ghcr tags-list API that `3.0.3` exists and `v3.0.3` does not; also re-verified the Gotenberg and Tika sidecar tags exist on Docker Hub (unaffected).

## Test plan

- [x] Confirmed `ghcr.io/paperless-ngx/paperless-ngx:3.0.3` resolves via the registry API
- [ ] Flux reconcile + pod comes up `Running` (owner to verify on-cluster)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SzhAtMmyvLkAMXT6LrNs67)_